### PR TITLE
Feature/update guard settings

### DIFF
--- a/.guardrc
+++ b/.guardrc
@@ -1,1 +1,3 @@
-Guard.options[:clear] = true
+# Configure the Pry interactor here.
+# https://github.com/guard/guard/wiki/Configuration-files
+

--- a/DEVELOPER_HOWTO.md
+++ b/DEVELOPER_HOWTO.md
@@ -21,7 +21,7 @@ $ be rake spec
 Requires MacOS Growl - available in the AppStore.
 
 ```
-$ bundle exec guard  start --no-interactions
+$ bundle exec guard
 ```
 
 ## CI

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,6 @@
 notification :growl, sticky: false, priority: 0
 logger level: :info
+clearing :on
 
 guard 'bundler' do
   watch('Gemfile')


### PR DESCRIPTION
**FORCE PUSHED** Mon Jan 12 14:39

### Motivation

```
$ be guard
```

was throwing deprecation warnings.  This PR resolves the warnings.