### PR TITLE
Feature/add jruby to travis ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 rvm:
   - 2.0.0
   - 2.1.2
+  - jruby-1.7.18
 
 script:
   - script/ci/travis/install-gem-ci.rb

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -54,18 +54,19 @@ Public License.}
   spec.add_dependency 'retriable', '~> 1.3', '>= 1.3.3.1'
   spec.add_dependency 'rubyzip', '~> 1.1'
 
-  # Development dependencies.
-  spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_development_dependency 'yard', '~> 0.8'
-  spec.add_development_dependency 'redcarpet', '~> 3.1'
-  spec.add_development_dependency 'travis', '~> 1.7'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-nav'
-
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'guard-rspec', '~> 4.3'
-  spec.add_development_dependency 'guard-bundler', '~> 2.0'
-  spec.add_development_dependency 'growl', '~> 1.0'
-  spec.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
+  # Development dependencies.  Developing with JRuby is not supported.
+  unless RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'rake', '~> 10.3'
+    spec.add_development_dependency 'yard', '~> 0.8'
+    spec.add_development_dependency 'redcarpet', '~> 3.1'
+    spec.add_development_dependency 'travis', '~> 1.7'
+    spec.add_development_dependency 'pry'
+    spec.add_development_dependency 'pry-nav'
+    spec.add_development_dependency 'rspec', '~> 3.0'
+    spec.add_development_dependency 'guard-rspec', '~> 4.3'
+    spec.add_development_dependency 'guard-bundler', '~> 2.0'
+    spec.add_development_dependency 'growl', '~> 1.0'
+    spec.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
+  end
 
 end


### PR DESCRIPTION
***WIP** Needs love; fails on travis.

```
EXEC: rake install
calabash 2.0.0.pre1 built to pkg/calabash-2.0.0.pre1.gem.
rake aborted!
Couldn't install gem, run `gem install /home/travis/build/calabash/calabash/pkg/calabash-2.0.0.pre1.gem' for more detailed output
FAIL: Could not install the gem with rake
$ bundle exec rake spec
Gem::LoadError: rake is not part of the bundle. Add it to Gemfile.
The command "bundle exec rake spec" exited with 1.
```