### PR TITLE
Gemspec: bundler will be required for calabash

### DIFF
--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -53,6 +53,7 @@ Public License.}
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'retriable', '~> 1.3', '>= 1.3.3.1'
   spec.add_dependency 'rubyzip', '~> 1.1'
+  spec.add_dependency 'bundler', '>= 1.3.0', '< 2.0'
 
   # Development dependencies.
   spec.add_development_dependency 'rake', '~> 10.3'
@@ -66,6 +67,5 @@ Public License.}
   spec.add_development_dependency 'guard-rspec', '~> 4.3'
   spec.add_development_dependency 'guard-bundler', '~> 2.0'
   spec.add_development_dependency 'growl', '~> 1.0'
-  spec.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
 
 end


### PR DESCRIPTION
#### Motivation

There has been discussion about making bundler and bundle exec a requirement for calabash 2.0.