### PR TITLE
Fix gemspec executable attribute

### DIFF
--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -34,7 +34,7 @@ Public License.}
   spec.platform      = Gem::Platform::RUBY
 
   spec.files         = gem_files
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = 'calabash'
   spec.require_paths = ['lib']
 
   spec.add_dependency 'cucumber', '~> 1.3'


### PR DESCRIPTION
**FORCE PUSHED** Mon Mar 23 17:26 CET

### Motivation

We want:

```
$ bundle exec calabash [cmd]
```