### PR TITLE
Feature/add ruby 2.2.1 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 rvm:
   - 2.0.0
   - 2.1.2
+  - 2.2.1
 
 script:
   - script/ci/travis/install-gem-ci.rb


### PR DESCRIPTION
### Motivation

Ruby 2.2.* is here, we have to test against it.