### PR TITLE
iOS Device needs reference to run-loop

### DIFF
--- a/lib/calabash/ios/device.rb
+++ b/lib/calabash/ios/device.rb
@@ -1,12 +1,14 @@
 module Calabash
   module IOS
     class Device < ::Calabash::Device
+
+      attr_reader :run_loop
+
       # TODO: Implement this method, remember to add unit tests
       def self.list_devices
         raise 'ni'
       end
 
-      # @todo this is a partial solution
       def calabash_start_app(application, options={})
         default_opts =
             {
@@ -16,7 +18,7 @@ module Calabash
             }
 
         launch_opts = default_opts.merge(options)
-        RunLoop.run(launch_opts)
+        @run_loop = RunLoop.run(launch_opts)
         ensure_test_server_ready
         device_info = fetch_device_info
         extract_device_info!(device_info)

--- a/spec/lib/ios/device_spec.rb
+++ b/spec/lib/ios/device_spec.rb
@@ -25,6 +25,8 @@ describe Calabash::IOS::Device do
       expect(device).to receive(:fetch_device_info).and_return({})
       expect(device).to receive(:extract_device_info!).and_return true
       expect(device.calabash_start_app(app)).to be_truthy
+      expect(device.run_loop).to be_a_kind_of(Hash)
+      expect(device.run_loop).to be == {}
     end
   end
 


### PR DESCRIPTION
### Motivation

**Calabash iOS Device needs to retain a reference to the current run-loop.** #36