### PR TITLE
Move the requires out of Calabash module

### DIFF
--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -1,20 +1,21 @@
+require File.join(File.dirname(__FILE__), '..', 'script', 'backwards_compatibility')
+require 'calabash/logger'
+require 'calabash/color'
+require 'calabash/version'
+require 'calabash/utility'
+require 'calabash/application'
+require 'calabash/environment'
+require 'calabash/operations'
+require 'calabash/managed'
+require 'calabash/device'
+require 'calabash/http'
+require 'calabash/server'
+require 'calabash/wait'
+require 'calabash/query'
+require 'calabash/query_result'
+require 'calabash/screenshot'
+
 module Calabash
-  require File.join(File.dirname(__FILE__), '..', 'script', 'backwards_compatibility')
-  require 'calabash/logger'
-  require 'calabash/color'
-  require 'calabash/version'
-  require 'calabash/utility'
-  require 'calabash/application'
-  require 'calabash/environment'
-  require 'calabash/operations'
-  require 'calabash/managed'
-  require 'calabash/device'
-  require 'calabash/http'
-  require 'calabash/server'
-  require 'calabash/wait'
-  require 'calabash/query'
-  require 'calabash/query_result'
-  require 'calabash/screenshot'
 
   include Utility
   include Calabash::Operations


### PR DESCRIPTION
### Motivation

Looking around the code, I am seeing a lot of `require calabash/<some gem file>` and  when implementing features and trying to build the gem, I am getting weird dependency problems.

I think we need to expose the guts of the gem to the gem.  Our users will `require calabash/cucumber`.

@TobiasRoikjer What say you?