### PR TITLE
Stop munging the LOAD_PATH

### DIFF
--- a/bin/calabash
+++ b/bin/calabash
@@ -59,6 +59,8 @@ module Calabash
             set_platform!(platform.to_sym)
 
             parse_arguments!
+          when 'version'
+            puts Calabash::VERSION
           when 'build'
             parse_build_arguments!
           when 'resign'

--- a/bin/calabash
+++ b/bin/calabash
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-# TODO: Remove this
-$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
-
 require 'calabash'
 
 module Calabash

--- a/build/android_test_server.rb
+++ b/build/android_test_server.rb
@@ -1,7 +1,8 @@
 module Calabash
   module Build
     module AndroidTestServer
-      require 'calabash/android'
+      require File.join(__dir__, '..', 'lib', 'calabash', 'environment')
+      require File.join(__dir__, '..', 'lib', 'calabash', 'android', 'environment')
 
       module Messages
         TEST_SERVER_NOT_FOUND = 'The test-server was not found'

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -1,8 +1,6 @@
 # coding: utf-8
 
-module Calabash
-  VERSION = '2.0.0.pre1'
-end
+require File.join(__dir__, 'lib', 'calabash', 'version')
 
 ruby_files = Dir.glob('{lib,bin}/**/*.rb')
 doc_files =  ['README.md', 'LICENSE', 'CONTRIBUTING.md', 'VERSIONING.md']

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -1,5 +1,4 @@
 # coding: utf-8
-require 'calabash/version'
 
 ruby_files = Dir.glob('{lib,bin}/**/*.rb')
 doc_files =  ['README.md', 'LICENSE', 'CONTRIBUTING.md', 'VERSIONING.md']
@@ -28,7 +27,22 @@ Public License.}
   spec.license       = 'EPL-1.0'
 
   spec.required_ruby_version = '>= 2.0'
-  spec.version       = Calabash::VERSION
+
+  spec.version       = lambda do
+    gem_version = nil
+    version_file = File.join(File.dirname(__FILE__), 'lib', 'calabash', 'version.rb')
+    lines = File.readlines(version_file)
+    lines.each do |line|
+      regex = /(\d+)\.(\d+)\.(\d+)\.?(pre\d*)?/
+      match = line.match(regex)
+      unless match.nil?
+        gem_version = match[0]
+        break
+      end
+    end
+    gem_version
+  end.call
+
   spec.platform      = Gem::Platform::RUBY
 
   spec.files         = gem_files

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -1,6 +1,4 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'calabash/version'
 
 ruby_files = Dir.glob('{lib,bin}/**/*.rb')

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -1,5 +1,9 @@
 # coding: utf-8
 
+module Calabash
+  VERSION = '2.0.0.pre1'
+end
+
 ruby_files = Dir.glob('{lib,bin}/**/*.rb')
 doc_files =  ['README.md', 'LICENSE', 'CONTRIBUTING.md', 'VERSIONING.md']
 gem_files = ruby_files + doc_files
@@ -28,21 +32,7 @@ Public License.}
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.version       = lambda do
-    gem_version = nil
-    version_file = File.join(File.dirname(__FILE__), 'lib', 'calabash', 'version.rb')
-    lines = File.readlines(version_file)
-    lines.each do |line|
-      regex = /(\d+)\.(\d+)\.(\d+)\.?(pre\d*)?/
-      match = line.match(regex)
-      unless match.nil?
-        gem_version = match[0]
-        break
-      end
-    end
-    gem_version
-  end.call
-
+  spec.version       = Calabash::VERSION
   spec.platform      = Gem::Platform::RUBY
 
   spec.files         = gem_files

--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -2,7 +2,6 @@ module Calabash
   require File.join(File.dirname(__FILE__), '..', 'script', 'backwards_compatibility')
   require 'calabash/logger'
   require 'calabash/color'
-  require 'calabash/version'
   require 'calabash/utility'
   require 'calabash/application'
   require 'calabash/environment'

--- a/lib/calabash/version.rb
+++ b/lib/calabash/version.rb
@@ -1,0 +1,3 @@
+module Calabash
+  VERSION = '2.0.0.pre1'
+end

--- a/lib/calabash/version.rb
+++ b/lib/calabash/version.rb
@@ -1,3 +1,0 @@
-module Calabash
-  VERSION = '2.0.0.pre1'
-end


### PR DESCRIPTION
**FORCE MERGE** Tue May 5 13:16 CET

### Motivation

By default, `bundler gem [gemname]` mangles the `$LOAD_PATH`.

http://guides.rubygems.org/patterns/

- [ ] @TobiasRoikjer Please provide feedback about ee35189.  I define the VERSION const _in_ the gemspec

### LOADING CODE

At its core, RubyGems exists to help you manage Ruby’s $LOAD_PATH, which is how the require statement picks up new code. There’s several things you can do to make sure you’re loading code the right way.

**Respect the global load path**

When packaging your gem files, you need to be careful of what is in your lib directory. Every gem you have installed gets its lib directory appended onto your $LOAD_PATH. This means any file on the top level of the lib directory could get required.

**Mangling the load path**

Gems should not change the $LOAD_PATH variable. RubyGems manages this for you. Code like this should not be necessary:

```
lp = File.expand_path(File.dirname(__FILE__))
unless $LOAD_PATH.include?(lp)
  $LOAD_PATH.unshift(lp)
end
```

Or:

```
__DIR__ = File.dirname(__FILE__)

$LOAD_PATH.unshift __DIR__ unless
  $LOAD_PATH.include?(__DIR__) ||
  $LOAD_PATH.include?(File.expand_path(__DIR__))
```

When RubyGems activates a gem, it adds your package’s lib folder to the $LOAD_PATH ready to be required normally by another lib or application. It is safe to assume you can then require any file in your lib folder.