### PR TITLE
Build: Properly require calabash/android

### DIFF
--- a/build/android_test_server.rb
+++ b/build/android_test_server.rb
@@ -1,10 +1,7 @@
 module Calabash
   module Build
     module AndroidTestServer
-      # TODO: These requirements should be specified elsewhere
-      require 'calabash/logger'
-      require 'calabash/environment'
-      require 'calabash/android/environment'
+      require 'calabash/android'
 
       module Messages
         TEST_SERVER_NOT_FOUND = 'The test-server was not found'


### PR DESCRIPTION
This fixes the issue with `$ rake build` failing