### PR TITLE
Require retriable 2.0

### DIFF
--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -46,6 +46,7 @@ Public License.}
   spec.add_dependency 'escape', '~> 0.0', '>= 0.0.4'
   spec.add_dependency 'sim_launcher', '< 0.5', '>= 0.4.13'
   spec.add_dependency 'run_loop', '>= 1.3.2', '< 2.0'
+  spec.add_dependency 'retriable', '~> 2.0'
 
   # These dependencies should match the xamarin-test-cloud dependencies.
   spec.add_dependency 'rubyzip', '~> 1.1'
@@ -55,7 +56,6 @@ Public License.}
   spec.add_dependency 'awesome_print'
   spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'json'
-  spec.add_dependency 'retriable'
 
   # Development dependencies.
   spec.add_development_dependency 'yard', '~> 0.8'

--- a/lib/calabash/http/retriable_client.rb
+++ b/lib/calabash/http/retriable_client.rb
@@ -19,8 +19,9 @@ module Calabash
         timeout = options.fetch(:timeout, 30)
         interval = options.fetch(:interval, 0.5)
 
+        intervals = Array.new(retries, interval)
         begin
-          Retriable.retriable(tries: retries, timeout: timeout, interval: interval) do
+          Retriable.retriable(intervals: intervals, timeout: timeout) do
             @client.get(@server.endpoint + request.route, request.params)
           end
         rescue => e

--- a/spec/lib/http/retriable_client_spec.rb
+++ b/spec/lib/http/retriable_client_spec.rb
@@ -45,8 +45,8 @@ describe Calabash::HTTP::RetriableClient do
     it 'should retry all if its requests with the given parameters' do
       route = 'my-route/to-my-server'
       request = Calabash::HTTP::Request.new(route)
-      arguments = {timeout: :my_timeout, interval: :my_interval, retries: :my_retries}
-      expected_arguments = {timeout: :my_timeout, interval: :my_interval, tries: :my_retries}
+      arguments = {timeout: 3600, interval: 42, retries: 13}
+      expected_arguments = {timeout: 3600, intervals: Array.new(13, 42)}
 
       expect(Retriable).to receive(:retriable).with(hash_including(expected_arguments)).and_return(true)
 


### PR DESCRIPTION
### Motivation

We want retriable 2.0.  Run-loop and test-cloud-command-line are now compatible with 1.3.3.1 <= retriable <  2.1.

@TobiasRoikjer The big change here are the args to retriable:

```
Try 3 times with a 2 second wait between each try.

;;; 1.x
Retriable(tries: 3, interval: 2)

;;; 2.0
Retriable(intervals: [2, 2, 2])
```