### PR TITLE
HTTP: retriable raises Calabash::HTTP::Error

### DIFF
--- a/lib/calabash/http/retriable_client.rb
+++ b/lib/calabash/http/retriable_client.rb
@@ -25,7 +25,7 @@ module Calabash
             @client.get(@server.endpoint + request.route, request.params)
           end
         rescue => e
-          raise HTTP::Error.new(e.message)
+          raise Calabash::HTTP::Error.new(e.message)
         end
       end
     end


### PR DESCRIPTION
### Motivation

This example makes me think we should be raise Calabash::HTTP::Error

**'should always raise a Calabash::HTTP::Error if an error is raised in the client call'**

The reasons the spec pass is because both HTTP::Error and Calabash::HTTP::Error are direct subclasses of StandardError.

My ios life cycle specs are not passing because of:

```
  1) Calabash::IOS::Device#calabash_stop_app raises an exception if server cannot be reached
     Failure/Error: expect(device.http_client).to receive(:get).raise_error(HTTP::Error)
     NameError:
       uninitialized constant HTTP::Error
     # ./spec/lib/ios/device_spec.rb:75:in `block (3 levels) in <top (required)>'
```

@TobiasRoikjer Please review and merge.