### PR TITLE
iOS Device:  Add runtime model

### DIFF
--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -14,8 +14,6 @@ module Calabash
       Calabash.send(:included, base)
     end
 
-    # Include old methods
-    require_old File.join('calabash-cucumber', 'lib', 'calabash-cucumber')
     include Calabash::IOS::Operations
 
     require 'calabash/ios/environment'

--- a/lib/calabash/ios/device_runtime_info.rb
+++ b/lib/calabash/ios/device_runtime_info.rb
@@ -7,31 +7,16 @@ module Calabash
 
       require 'run_loop'
 
-      # @!visibility private
-      GESTALT_IPHONE = 'iPhone'
+      # Creates a new instance of DeviceRuntimeInfo.
+      # @param [Hash] device_info The result of calling the version route on
+      #  on the server
+      # @return [Calabash::IOS::DeviceRuntimeInfo] A new info object.
+      def initialize(device_info)
+        @device_info = device_info
+      end
 
-      # @!visibility private
-      GESTALT_IPAD = 'iPad'
-
-      # @!visibility private
-      GESTALT_IPHONE5 = '4-inch'
-
-      # @!visibility private
-      GESTALT_SIM_SYS = 'x86_64'
-
-      # @!visibility private
-      GESTALT_IPOD = 'iPod'
-
-      # @!attribute [r] endpoint
-      # The http address of this device.
-      # @example
-      #  http://192.168.0.2:37265
-      # @return [String] an ip address with port number.
-      attr_reader :endpoint
 
       # The device family of this device.
-      #
-      # @note Also know as the form factor.
       #
       # @example
       #  # will be one of
@@ -39,205 +24,41 @@ module Calabash
       #  iPod
       #  iPad
       #
-      # @!attribute [r] device_family
       # @return [String] the device family
-      attr_reader :device_family
+      def device_family
+        @device_family ||= lambda do
+         return nil if device_info.nil?
 
-      # @!visibility private
-      # @attribute [r] simulator_details
-      # @return [String] Additional details about the simulator.  If this device
-      #  is a physical device, returns nil.
-      attr_reader :simulator_details
+         simulator_device = device_info['simulator_device']
 
-      # The `major.minor.[.patch]` version of iOS that is running on this device.
-      #
-      # @example
-      #  7.1
-      #  6.1.2
-      #  5.1.1
-      #
-      # @attribute [r] ios_version
-      # @return [RunLoop::Version] The
-      attr_reader :ios_version
+         if simulator_device && !simulator_device.empty?
+           simulator_device
+         else
+           system.split(/[\d,.]/).first
+         end
+        end
+      end
 
-      # The hardware architecture of this device.  Also known as the chip set.
-      #
-      # @example
-      #  # simulator
-      #  i386
-      #  x86_64
-      #
-      # @example
-      #  # examples from physical devices
-      #  armv6
-      #  armv7s
-      #  arm64
-      #
-      # @attribute [r] system
-      # @return [String] the hardware architecture of this device.
-      #  this device.
-      attr_reader :system
-
-      # The version of the embedded Calabash server that is running in the
-      # app under test on this device.
-      #
-      # @example
-      #  0.9.168
-      #  0.10.0.pre1
-      #
-      # @attribute [r] server_version
-      # @return [RunLoop::Version] The major.minor.patch[.pre\d] version of the
-      #   embedded Calabash server
-      attr_reader :server_version
-
-      # Indicates whether or not the app under test on this device is an
-      #  iPhone-only app that is being emulated on an iPad.
-      #
-      # @note If the `1x` or `2x` button is visible, then the app is being
-      #  emulated.
-      #
-      # @attribute [r] iphone_app_emulated_on_ipad
-      # @return [Boolean] `true` if the app under test is emulated
-      attr_reader :iphone_app_emulated_on_ipad
-
-      # The form factor of this device.
-      # @attribute [r] form_factor
+      # The form factor of the device under test.
       #
       # Will be one of:
+      #
       #   * ipad
       #   * iphone 4in
       #   * iphone 3.5in
       #   * iphone 6
       #   * iphone 6+
-      #   * "" # if no information can be found.
-      attr_reader :form_factor
-
-      # For Calabash server version > 0.10.2 provides
-      # device specific screen information.
+      #   * unknown # if no information can be found.
       #
-      # This is a hash of form:
-      #  {
-      #    :sample => 1,
-      #    :height => 1334,
-      #    :width => 750,
-      #    :scale" => 2
-      #  }
+      # @note iPod is not on this list for a reason!  An iPod has an iPhone
+      #  form factor.
       #
-      #
-      # @attribute [r] screen_dimensions
-      # @return [Hash] screen dimensions, scale and down/up sampling fraction.
-      attr_reader :screen_dimensions
-
-      # Creates a new instance of DeviceRuntimeInfo.
-      # @param [Hash] device_info The result of calling the version route on
-      #  on the server
-      # @return [Calabash::IOS::DeviceRuntimeInfo] A new info object.
-      def initialize(device_info)
-        simulator_device = device_info['simulator_device']
-        @system = device_info['system']
-        if @system
-          @device_family = @system.eql?(GESTALT_SIM_SYS) ? simulator_device : @system.split(/[\d,.]/).first
-        end
-        @simulator_details = device_info['simulator']
-
-        if device_info['iOS_version']
-          @ios_version = RunLoop::Version.new(device_info['iOS_version'])
-        end
-
-        @server_version = device_info['version']
-        @iphone_app_emulated_on_ipad = device_info['iphone_app_emulated_on_ipad']
-        @iphone_4in = device_info['4inch']
-        screen_dimensions = device_info['screen_dimensions']
-        if screen_dimensions
-          @screen_dimensions = {}
-          screen_dimensions.each_pair do |key,val|
-            @screen_dimensions[key.to_sym] = val
-          end
-        end
-      end
-
-      # Is this device a simulator or physical device?
-      # @return [Boolean] true if this device is a simulator
-      def simulator?
-        system.eql?(GESTALT_SIM_SYS)
-      end
-
-      # Is this device a device or simulator?
-      # @return [Boolean] true if this device is a physical device
-      def device?
-        not simulator?
-      end
-
-      # Is this device an iPhone?
-      # @return [Boolean] true if this device is an iphone
-      def iphone?
-        device_family.eql? GESTALT_IPHONE
-      end
-
-      # Is this device an iPod?
-      # @return [Boolean] true if this device is an ipod
-      def ipod?
-        device_family.eql? GESTALT_IPOD
-      end
-
-      # Is this device an iPad?
-      # @return [Boolean] true if this device is an ipad
-      def ipad?
-        device_family.eql? GESTALT_IPAD
-      end
-
-      # Is this device a 4in iPhone?
-      # @return [Boolean] true if this device is a 4in iphone
-      def iphone_4in?
-        form_factor == 'iphone 4in'
-      end
-
-      # Is this device an iPhone 6?
-      # @return [Boolean] true if this device is an iPhone 6
-      def iphone_6?
-        form_factor == 'iphone 6'
-      end
-
-      # Is this device an iPhone 6+?
-      # @return [Boolean] true if this device is an iPhone 6+
-      def iphone_6_plus?
-        form_factor == 'iphone 6+'
-      end
-
-      # Is this device an iPhone 3.5in?
-      # @return [Boolean] true if this device is an iPhone 3.5in?
-      def iphone_35in?
-        form_factor == 'iphone 3.5in'
-      end
-
-      # The major iOS version of this device.
-      # @return [String] the major version of the OS
-      def ios_major_version
-        version_hash(ios_version)[:major_version]
-      end
-
-      # Is this device running iOS 8?
-      # @return [Boolean] true if the major version of the OS is 8
-      def ios8?
-        ios_major_version.eql?('8')
-      end
-
-      # Is this device running iOS 7?
-      # @return [Boolean] true if the major version of the OS is 7
-      def ios7?
-        ios_major_version.eql?('7')
-      end
-
-      # Is this device running iOS 6?
-      # @return [Boolean] true if the major version of the OS is 6
-      def ios6?
-        ios_major_version.eql?('6')
-      end
-
-      # Is this device running iOS 5?
-      # @return [Boolean] true if the major version of the OS is 5
-      def ios5?
-        ios_major_version.eql?('5')
+      # @return [String] The form factor of the device under test.
+      def form_factor
+        @form_factor ||= lambda do
+          return nil if device_info.nil?
+          device_info['form_factor']
+        end.call
       end
 
       # Is the app that is running an iPhone-only app emulated on an iPad?
@@ -248,8 +69,92 @@ module Calabash
       # @return [Boolean] true if the app running on this devices is an
       #   iPhone-only app emulated on an iPad
       def iphone_app_emulated_on_ipad?
-        iphone_app_emulated_on_ipad
+        @iphone_app_emulated_on_ipad ||= lambda do
+          return nil if device_info.nil?
+          device_info['iphone_app_emulated_on_ipad']
+        end.call
       end
+
+
+      # The iOS version on the test device.
+      #
+      # @return [RunLoop::Version] The major.minor.patch[.pre\d] version of the
+      #   iOS version on the device.
+      def ios_version
+        @ios_version ||= lambda do
+          return nil if device_info.nil?
+
+          version_string = device_info['iOS_version']
+
+          return nil if version_string.nil? || version_string.empty?
+
+          RunLoop::Version.new(version_string)
+        end.call
+      end
+
+      # Information about the runtime screen dimensions of the app under test.
+      #
+      # This is a hash of form:
+      #
+      # ```
+      #    {
+      #      :sample => 1,
+      #      :height => 1334,
+      #      :width => 750,
+      #      :scale" => 2
+      #    }
+      # ```
+      #
+      # @return [Hash] screen dimensions, scale and down/up sampling fraction.
+      def screen_dimensions
+        @screen_dimensions ||= lambda do
+          return nil if device_info.nil?
+          screen_dimensions = device_info['screen_dimensions']
+          @screen_dimensions = {}
+          screen_dimensions.each_pair do |key,val|
+            @screen_dimensions[key.to_sym] = val
+          end
+        end.call
+      end
+
+      # The version of the embedded Calabash server that is running in the
+      # app under test on this device.
+      #
+      # @return [RunLoop::Version] The major.minor.patch[.pre\d] version of the
+      #   embedded Calabash server
+      def server_version
+        @server_version ||= lambda do
+          return nil if device_info.nil?
+
+          version_string = device_info['version']
+
+          return nil if version_string.nil? || version_string.empty?
+
+          RunLoop::Version.new(version_string)
+        end.call
+      end
+
+      private
+
+      # @!visibility private
+      # Details about the device.  For iOS Simulators, this will be x86_64,
+      # which is not very helpful.   For physical devices, this will be the
+      # internal Apple device name.  For example, the `iPhone 6+` will report
+      # `iPhone7,1` and the `iPhone 5s` will report `iPhone 6`.
+      #
+      # @return [String] Information about the device under test.
+      def system
+        @system ||= lambda do
+          return nil if device_info.nil?
+
+          device_info['system']
+        end.call
+      end
+
+      # @!visibility private
+      # The hash passed to initialize.
+      attr_reader :device_info
+
     end
   end
 end

--- a/lib/calabash/ios/device_runtime_info.rb
+++ b/lib/calabash/ios/device_runtime_info.rb
@@ -1,0 +1,255 @@
+module Calabash
+  module IOS
+
+    # This class provides information about the device under test that can
+    # only be obtained at run time.
+    class DeviceRuntimeInfo
+
+      require 'run_loop'
+
+      # @!visibility private
+      GESTALT_IPHONE = 'iPhone'
+
+      # @!visibility private
+      GESTALT_IPAD = 'iPad'
+
+      # @!visibility private
+      GESTALT_IPHONE5 = '4-inch'
+
+      # @!visibility private
+      GESTALT_SIM_SYS = 'x86_64'
+
+      # @!visibility private
+      GESTALT_IPOD = 'iPod'
+
+      # @!attribute [r] endpoint
+      # The http address of this device.
+      # @example
+      #  http://192.168.0.2:37265
+      # @return [String] an ip address with port number.
+      attr_reader :endpoint
+
+      # The device family of this device.
+      #
+      # @note Also know as the form factor.
+      #
+      # @example
+      #  # will be one of
+      #  iPhone
+      #  iPod
+      #  iPad
+      #
+      # @!attribute [r] device_family
+      # @return [String] the device family
+      attr_reader :device_family
+
+      # @!visibility private
+      # @attribute [r] simulator_details
+      # @return [String] Additional details about the simulator.  If this device
+      #  is a physical device, returns nil.
+      attr_reader :simulator_details
+
+      # The `major.minor.[.patch]` version of iOS that is running on this device.
+      #
+      # @example
+      #  7.1
+      #  6.1.2
+      #  5.1.1
+      #
+      # @attribute [r] ios_version
+      # @return [RunLoop::Version] The
+      attr_reader :ios_version
+
+      # The hardware architecture of this device.  Also known as the chip set.
+      #
+      # @example
+      #  # simulator
+      #  i386
+      #  x86_64
+      #
+      # @example
+      #  # examples from physical devices
+      #  armv6
+      #  armv7s
+      #  arm64
+      #
+      # @attribute [r] system
+      # @return [String] the hardware architecture of this device.
+      #  this device.
+      attr_reader :system
+
+      # The version of the embedded Calabash server that is running in the
+      # app under test on this device.
+      #
+      # @example
+      #  0.9.168
+      #  0.10.0.pre1
+      #
+      # @attribute [r] server_version
+      # @return [RunLoop::Version] The major.minor.patch[.pre\d] version of the
+      #   embedded Calabash server
+      attr_reader :server_version
+
+      # Indicates whether or not the app under test on this device is an
+      #  iPhone-only app that is being emulated on an iPad.
+      #
+      # @note If the `1x` or `2x` button is visible, then the app is being
+      #  emulated.
+      #
+      # @attribute [r] iphone_app_emulated_on_ipad
+      # @return [Boolean] `true` if the app under test is emulated
+      attr_reader :iphone_app_emulated_on_ipad
+
+      # The form factor of this device.
+      # @attribute [r] form_factor
+      #
+      # Will be one of:
+      #   * ipad
+      #   * iphone 4in
+      #   * iphone 3.5in
+      #   * iphone 6
+      #   * iphone 6+
+      #   * "" # if no information can be found.
+      attr_reader :form_factor
+
+      # For Calabash server version > 0.10.2 provides
+      # device specific screen information.
+      #
+      # This is a hash of form:
+      #  {
+      #    :sample => 1,
+      #    :height => 1334,
+      #    :width => 750,
+      #    :scale" => 2
+      #  }
+      #
+      #
+      # @attribute [r] screen_dimensions
+      # @return [Hash] screen dimensions, scale and down/up sampling fraction.
+      attr_reader :screen_dimensions
+
+      # Creates a new instance of DeviceRuntimeInfo.
+      # @param [Hash] device_info The result of calling the version route on
+      #  on the server
+      # @return [Calabash::IOS::DeviceRuntimeInfo] A new info object.
+      def initialize(device_info)
+        simulator_device = device_info['simulator_device']
+        @system = device_info['system']
+        if @system
+          @device_family = @system.eql?(GESTALT_SIM_SYS) ? simulator_device : @system.split(/[\d,.]/).first
+        end
+        @simulator_details = device_info['simulator']
+
+        if device_info['iOS_version']
+          @ios_version = RunLoop::Version.new(device_info['iOS_version'])
+        end
+
+        @server_version = device_info['version']
+        @iphone_app_emulated_on_ipad = device_info['iphone_app_emulated_on_ipad']
+        @iphone_4in = device_info['4inch']
+        screen_dimensions = device_info['screen_dimensions']
+        if screen_dimensions
+          @screen_dimensions = {}
+          screen_dimensions.each_pair do |key,val|
+            @screen_dimensions[key.to_sym] = val
+          end
+        end
+      end
+
+      # Is this device a simulator or physical device?
+      # @return [Boolean] true if this device is a simulator
+      def simulator?
+        system.eql?(GESTALT_SIM_SYS)
+      end
+
+      # Is this device a device or simulator?
+      # @return [Boolean] true if this device is a physical device
+      def device?
+        not simulator?
+      end
+
+      # Is this device an iPhone?
+      # @return [Boolean] true if this device is an iphone
+      def iphone?
+        device_family.eql? GESTALT_IPHONE
+      end
+
+      # Is this device an iPod?
+      # @return [Boolean] true if this device is an ipod
+      def ipod?
+        device_family.eql? GESTALT_IPOD
+      end
+
+      # Is this device an iPad?
+      # @return [Boolean] true if this device is an ipad
+      def ipad?
+        device_family.eql? GESTALT_IPAD
+      end
+
+      # Is this device a 4in iPhone?
+      # @return [Boolean] true if this device is a 4in iphone
+      def iphone_4in?
+        form_factor == 'iphone 4in'
+      end
+
+      # Is this device an iPhone 6?
+      # @return [Boolean] true if this device is an iPhone 6
+      def iphone_6?
+        form_factor == 'iphone 6'
+      end
+
+      # Is this device an iPhone 6+?
+      # @return [Boolean] true if this device is an iPhone 6+
+      def iphone_6_plus?
+        form_factor == 'iphone 6+'
+      end
+
+      # Is this device an iPhone 3.5in?
+      # @return [Boolean] true if this device is an iPhone 3.5in?
+      def iphone_35in?
+        form_factor == 'iphone 3.5in'
+      end
+
+      # The major iOS version of this device.
+      # @return [String] the major version of the OS
+      def ios_major_version
+        version_hash(ios_version)[:major_version]
+      end
+
+      # Is this device running iOS 8?
+      # @return [Boolean] true if the major version of the OS is 8
+      def ios8?
+        ios_major_version.eql?('8')
+      end
+
+      # Is this device running iOS 7?
+      # @return [Boolean] true if the major version of the OS is 7
+      def ios7?
+        ios_major_version.eql?('7')
+      end
+
+      # Is this device running iOS 6?
+      # @return [Boolean] true if the major version of the OS is 6
+      def ios6?
+        ios_major_version.eql?('6')
+      end
+
+      # Is this device running iOS 5?
+      # @return [Boolean] true if the major version of the OS is 5
+      def ios5?
+        ios_major_version.eql?('5')
+      end
+
+      # Is the app that is running an iPhone-only app emulated on an iPad?
+      #
+      # @note If the app is running in emulation mode, there will be a 1x or 2x
+      #   scale button visible on the iPad.
+      #
+      # @return [Boolean] true if the app running on this devices is an
+      #   iPhone-only app emulated on an iPad
+      def iphone_app_emulated_on_ipad?
+        iphone_app_emulated_on_ipad
+      end
+    end
+  end
+end

--- a/lib/calabash/ios/runtime_attributes.rb
+++ b/lib/calabash/ios/runtime_attributes.rb
@@ -3,14 +3,14 @@ module Calabash
 
     # This class provides information about the device under test that can
     # only be obtained at run time.
-    class DeviceRuntimeInfo
+    class RuntimeAttributes
 
       require 'run_loop'
 
       # Creates a new instance of DeviceRuntimeInfo.
       # @param [Hash] device_info The result of calling the version route on
       #  on the server
-      # @return [Calabash::IOS::DeviceRuntimeInfo] A new info object.
+      # @return [Calabash::IOS::RuntimeAttributes] A new info object.
       def initialize(device_info)
         @device_info = device_info
       end

--- a/spec/integration/ios/device_spec.rb
+++ b/spec/integration/ios/device_spec.rb
@@ -83,4 +83,29 @@ describe Calabash::IOS::Device do
     end
   end
 
+  describe 'runtime API' do
+
+    before do
+      device.ensure_app_installed(app)
+      device.start_app(app)
+    end
+
+    it 'can report runtime attributes' do
+      expect(device.device_family).to be == 'iPhone'
+      expect(device.form_factor).to be == 'iphone 4in'
+      expect(device.ios_version).to be == run_loop_device.version
+      expect(device.iphone_app_emulated_on_ipad?).to be == false
+      expect(device.physical_device?).to be == false
+      expect(device.screen_dimensions).to be == { :sample => 1,
+                                                  :height => 1136,
+                                                  :width => 640,
+                                                  :scale => 2 }
+      run_loop_app = RunLoop::App.new(abp)
+      path_to_exec = File.join(abp, run_loop_app.executable_name)
+      raw_output = `xcrun strings #{path_to_exec} | grep -E 'CALABASH VERSION'`
+      version = raw_output.split(' ')[2]
+      expect(device.server_version).to be == RunLoop::Version.new(version)
+      expect(device.simulator?).to be == true
+    end
+  end
 end

--- a/spec/lib/ios/device_spec.rb
+++ b/spec/lib/ios/device_spec.rb
@@ -25,7 +25,7 @@ describe Calabash::IOS::Device do
     end.new
   end
 
-  let(:device_info) do
+  let(:runtime_attrs) do
     Class.new do
       def simulator?; ; end
     end.new
@@ -271,12 +271,12 @@ describe Calabash::IOS::Device do
     end
 
     describe '#stop_app' do
-      before { device.instance_variable_set(:@runtime_info, {}) }
+      before { device.instance_variable_set(:@runtime_attributes, {}) }
 
       it 'clears the runtime_info if the server is not responding' do
         expect(device).to receive(:test_server_responding?).and_return(false)
         expect(device.stop_app).to be_truthy
-        expect(device.send(:runtime_info)).to be == nil
+        expect(device.send(:runtime_attributes)).to be == nil
       end
 
       it "calls the server 'exit' route" do
@@ -287,7 +287,7 @@ describe Calabash::IOS::Device do
         expect(device.http_client).to receive(:get).with(request).and_return([])
 
         expect(device.stop_app).to be_truthy
-        expect(device.send(:runtime_info)).to be == nil
+        expect(device.send(:runtime_attributes)).to be == nil
       end
 
       it 'raises an exception if server cannot be reached' do
@@ -295,7 +295,7 @@ describe Calabash::IOS::Device do
         expect(device.http_client).to receive(:get).and_raise(Calabash::HTTP::Error)
 
         expect { device.stop_app }.to raise_error
-        expect(device.send(:runtime_info)).to be == nil
+        expect(device.send(:runtime_attributes)).to be == nil
       end
     end
 
@@ -529,13 +529,13 @@ describe Calabash::IOS::Device do
     end
 
     it '#wait_for_server_to_start' do
-      device_info = {:device => :info}
+      runtime_attrs = {:device => :info}
       expect(device).to receive(:ensure_test_server_ready).and_return true
-      expect(device).to receive(:fetch_device_info).and_return device_info
-      expect(device).to receive(:new_device_runtime_info).with(device_info).and_return device_info
+      expect(device).to receive(:fetch_runtime_attributes).and_return runtime_attrs
+      expect(device).to receive(:new_device_runtime_info).with(runtime_attrs).and_return runtime_attrs
 
       expect(device.send(:wait_for_server_to_start)).to be_truthy
-      expect(device.send(:runtime_info)).to be == device_info
+      expect(device.send(:runtime_attributes)).to be == runtime_attrs
     end
 
     describe '#expect_app_installed_on_simulator' do
@@ -708,7 +708,7 @@ describe Calabash::IOS::Device do
       end
     end
 
-    describe '#fetch_device_info' do
+    describe '#fetch_runtime_attributes' do
       let(:dummy_http_response) { Class.new {def body; '[]'; end}.new }
       let(:request) { Calabash::HTTP::Request.new('version') }
 
@@ -720,26 +720,26 @@ describe Calabash::IOS::Device do
       it 'raises an error if response cannot be parsed to JSON' do
         expect(JSON).to receive(:parse).with('[]').and_raise
         expect {
-          device.send(:fetch_device_info)
+          device.send(:fetch_runtime_attributes)
         }.to raise_error
       end
 
       it 'parses the body of the response to a ruby object' do
-        expect(device.send(:fetch_device_info)).to be == []
+        expect(device.send(:fetch_runtime_attributes)).to be == []
       end
     end
 
     describe '#method_missing' do
       describe 'runtime_info is nil' do
         it 'and runtime_info implements the method' do
-          device.instance_variable_set(:@runtime_info, nil)
+          device.instance_variable_set(:@runtime_attributes, nil)
           expect do
             device.simulator?
           end.to raise_error
         end
 
         it 'and runtime_info and self does not implement the method' do
-          device.instance_variable_set(:@runtime_info, nil)
+          device.instance_variable_set(:@runtime_attributes, nil)
           expect do
             device.send(:unknown_method)
           end.to raise_error
@@ -749,8 +749,8 @@ describe Calabash::IOS::Device do
       describe '#runtime_info is non-nil' do
         describe 'forwarding the method to runtime_info' do
           it 'raises an error when the runtime_info method raises an error' do
-            device.instance_variable_set(:@runtime_info, device_info)
-            expect(device_info).to receive(:simulator?).and_raise ArgumentError
+            device.instance_variable_set(:@runtime_attributes, runtime_attrs)
+            expect(runtime_attrs).to receive(:simulator?).and_raise ArgumentError
             expect {
               expect(device.send(:simulator?))
             }.to raise_error ArgumentError
@@ -758,8 +758,8 @@ describe Calabash::IOS::Device do
           end
 
           it 'calls and returns the runtime_info method' do
-            device.instance_variable_set(:@runtime_info, device_info)
-            expect(device_info).to receive(:simulator?).and_return 42
+            device.instance_variable_set(:@runtime_attributes, runtime_attrs)
+            expect(runtime_attrs).to receive(:simulator?).and_return 42
             expect(device.send(:simulator?)).to be == 42
           end
         end

--- a/spec/lib/ios/device_spec.rb
+++ b/spec/lib/ios/device_spec.rb
@@ -28,6 +28,11 @@ describe Calabash::IOS::Device do
   let(:runtime_attrs) do
     Class.new do
       def simulator?; ; end
+      def device_family; ; end
+      def form_factor; ;  end
+      def iphone_app_emulated_on_ipad?; ; end
+      def server_version; ; end
+      def screen_dimensions; ; end
     end.new
   end
 
@@ -729,41 +734,115 @@ describe Calabash::IOS::Device do
       end
     end
 
-    describe '#method_missing' do
-      describe 'runtime_info is nil' do
-        it 'and runtime_info implements the method' do
-          device.instance_variable_set(:@runtime_attributes, nil)
-          expect do
-            device.simulator?
-          end.to raise_error
-        end
-
-        it 'and runtime_info and self does not implement the method' do
-          device.instance_variable_set(:@runtime_attributes, nil)
-          expect do
-            device.send(:unknown_method)
-          end.to raise_error
-        end
+    describe '#expect_runtime_attributes_available' do
+      it 'raises an error when runtime_attributes are not available' do
+        device.instance_variable_set(:@runtime_attributes, nil)
+        expect {
+          device.send(:expect_runtime_attributes_available, 'foo')
+        }.to raise_error
       end
 
-      describe '#runtime_info is non-nil' do
-        describe 'forwarding the method to runtime_info' do
-          it 'raises an error when the runtime_info method raises an error' do
-            device.instance_variable_set(:@runtime_attributes, runtime_attrs)
-            expect(runtime_attrs).to receive(:simulator?).and_raise ArgumentError
-            expect {
-              expect(device.send(:simulator?))
-            }.to raise_error ArgumentError
-
-          end
-
-          it 'calls and returns the runtime_info method' do
-            device.instance_variable_set(:@runtime_attributes, runtime_attrs)
-            expect(runtime_attrs).to receive(:simulator?).and_return 42
-            expect(device.send(:simulator?)).to be == 42
-          end
-        end
+      it 'returns true if runtime_attributes are available' do
+        device.instance_variable_set(:@runtime_attributes, 'anything')
+        expect(device.send(:expect_runtime_attributes_available, 'foo')).to be == true
       end
+    end
+
+    describe '#device_family' do
+      it 'raises an error if runtime_attributes are not set' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_raise
+        expect do
+          device.device_family
+        end.to raise_error
+      end
+
+      it 'asks runtime_attributes for the value' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_return true
+        expect(runtime_attrs).to receive(:device_family).and_return 'something'
+        expect(device).to receive(:runtime_attributes).and_return runtime_attrs
+        expect(device.device_family).to be == 'something'
+      end
+    end
+
+    describe '#form_factor' do
+      it 'raises an error if runtime_attributes are not set' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_raise
+        expect do
+          device.form_factor
+        end.to raise_error
+      end
+
+      it 'asks runtime_attributes for the value' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_return true
+        expect(runtime_attrs).to receive(:form_factor).and_return 'something'
+        expect(device).to receive(:runtime_attributes).and_return runtime_attrs
+        expect(device.form_factor).to be == 'something'
+      end
+    end
+
+    it '#ios_version' do
+      expect(device).to receive(:run_loop_device).and_return run_loop_device
+      expect(device.ios_version).to be == run_loop_device.version
+    end
+
+    describe '#iphone_app_emulated_on_ipad?' do
+      it 'raises an error if runtime_attributes are not set' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_raise
+        expect do
+          device.iphone_app_emulated_on_ipad?
+        end.to raise_error
+      end
+
+      it 'asks runtime_attributes for the value' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_return true
+        expect(runtime_attrs).to receive(:iphone_app_emulated_on_ipad?).and_return 'something'
+        expect(device).to receive(:runtime_attributes).and_return runtime_attrs
+        expect(device.iphone_app_emulated_on_ipad?).to be == 'something'
+      end
+    end
+
+    it '#physical_device?' do
+      expect(device).to receive(:run_loop_device).and_return run_loop_device
+      expect(run_loop_device).to receive(:physical_device?).and_return 'something'
+      expect(device.physical_device?).to be == 'something'
+    end
+
+    describe '#screen_dimensions' do
+      it 'raises an error if runtime_attributes are not set' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_raise
+        expect do
+          device.screen_dimensions
+        end.to raise_error
+      end
+
+      it 'asks runtime_attributes for the value' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_return true
+        expect(runtime_attrs).to receive(:screen_dimensions).and_return 'something'
+        expect(device).to receive(:runtime_attributes).and_return runtime_attrs
+        expect(device.screen_dimensions).to be == 'something'
+      end
+    end
+
+    describe '#server_version' do
+      it 'raises an error if runtime_attributes are not set' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_raise
+        expect do
+          device.server_version
+        end.to raise_error
+      end
+
+      it 'asks runtime_attributes for the value' do
+        expect(device).to receive(:expect_runtime_attributes_available).and_return true
+        expect(runtime_attrs).to receive(:server_version).and_return 'something'
+        expect(device).to receive(:runtime_attributes).and_return runtime_attrs
+        expect(device.server_version).to be == 'something'
+      end
+    end
+
+    it '#simulator>' do
+      expect(device).to receive(:run_loop_device).and_return run_loop_device
+      expect(run_loop_device).to receive(:simulator?).and_return 'something'
+      expect(device.simulator?).to be == 'something'
     end
   end
 end

--- a/spec/lib/ios/runtime_attributes_spec.rb
+++ b/spec/lib/ios/runtime_attributes_spec.rb
@@ -1,0 +1,156 @@
+
+describe Calabash::IOS::RuntimeAttributes do
+
+  it '.new' do
+    attrs = Calabash::IOS::RuntimeAttributes.new({:a => 'a'})
+    expect(attrs.instance_variable_get(:@runtime_info)).to be == {:a => 'a'}
+  end
+
+  let(:attrs) { Calabash::IOS::RuntimeAttributes.new(nil) }
+
+  describe '#device family' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.device_family).to be == nil
+    end
+
+    describe 'simulators' do
+      it 'returns value of :simulator_device if it is non-nil and not empty' do
+        expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'simulator_device' => 'iPhone'})
+        expect(attrs.device_family).to be == 'iPhone'
+      end
+
+      it 'returns nil if :simulator_device is empty' do
+        expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'simulator_device' => ''})
+        expect(attrs.device_family).to be == nil
+      end
+
+      it 'returns nil if :simulator_device is nil' do
+        expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'simulator_device' => nil})
+        expect(attrs.device_family).to be == nil
+      end
+    end
+
+    describe 'physical devices' do
+      it "returns the device family by parsing the value of 'system'" do
+        expect(attrs).to receive(:runtime_info).at_least(:once).and_return({ })
+        expect(attrs).to receive(:system).and_return('iPhone7,1')
+        expect(attrs.device_family).to be == 'iPhone'
+      end
+
+      it "returns nil if 'system' is nil" do
+        expect(attrs).to receive(:runtime_info).at_least(:once).and_return({ })
+        expect(attrs).to receive(:system).and_return(nil)
+        expect(attrs.device_family).to be == nil
+      end
+    end
+  end
+
+  describe '#form_factor' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.form_factor).to be == nil
+    end
+
+    it 'returns the value of :form_factor' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'form_factor' => 'hello'})
+      expect(attrs.form_factor).to be == 'hello'
+    end
+  end
+
+  describe '#ios_version' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.ios_version).to be == nil
+    end
+
+    it 'returns nil if :iOS_version value is nil' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'iOS_version' => nil})
+      expect(attrs.ios_version).to be == nil
+    end
+
+    it 'returns nil if :iOS_version value is empty' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'iOS_version' => ''})
+      expect(attrs.ios_version).to be == nil
+    end
+
+    it 'returns a RunLoop::Version if value of :iOS_version can be parsed' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'iOS_version' => '8.1'})
+      expect(attrs.ios_version).to be == RunLoop::Version.new('8.1')
+    end
+
+    it 'returns nil if :iOS_version value cannot be parsed' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'iOS_version' => '8.1'})
+      expect(RunLoop::Version).to receive(:new).and_raise
+      expect(attrs.ios_version).to be == nil
+    end
+  end
+
+  describe '#screen_dimensions' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.screen_dimensions).to be == nil
+    end
+
+    it 'returns a hash when screen_dimensions is a hash' do
+      dimensions =
+          {
+              'screen_dimensions' =>
+                  {
+                      'a' => 1,
+                      'b' => 2,
+                      'c' => 3
+                  }
+          }
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return(dimensions)
+      expected =
+          {
+              :a => 1,
+              :b => 2,
+              :c => 3
+          }
+      expect(attrs.screen_dimensions).to be == expected
+    end
+  end
+
+  describe '#server_version' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.server_version).to be == nil
+    end
+
+    it 'returns nil if :version value is nil' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'version' => nil})
+      expect(attrs.server_version).to be == nil
+    end
+
+    it 'returns nil if :version value is empty' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'version' => ''})
+      expect(attrs.server_version).to be == nil
+    end
+
+    it 'returns a RunLoop::Version if value of :version can be parsed' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'version' => '8.1'})
+      expect(attrs.server_version).to be == RunLoop::Version.new('8.1')
+    end
+
+    it 'returns nil if :version value cannot be parsed' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'version' => '8.1'})
+      expect(RunLoop::Version).to receive(:new).and_raise
+      expect(attrs.server_version).to be == nil
+    end
+  end
+
+  describe '#system' do
+    it 'returns nil when runtime info is nil' do
+      expect(attrs).to receive(:runtime_info).and_return nil
+      expect(attrs.send(:system)).to be == nil
+    end
+
+    it 'returns the value of :system' do
+      expect(attrs).to receive(:runtime_info).at_least(:once).and_return({'system' => 'hello'})
+      expect(attrs.send(:system)).to be == 'hello'
+    end
+  end
+end
+


### PR DESCRIPTION
## TL;DR

Some information about the device and app under test can only be extracted at runtime via a server query.

#### iOS Simulators

Many of the Calabash::Cucumber::Device class methods can be replaced be by inspecting the RunLoop::Device class.

#### Physical Devices

Most of the Calabash::Cucumber::Device class methods could be replaced _if_ we could use a third-party tool like `libimobiledevice`.

## Discussion

Some information about the device and app under test can only be extracted at runtime via a server query.

It is not possible to answer all of these questions for physical devices because the UDID of the device is opaque.  We can't know, for example, if the device is an iPad or iPhone 6.

#### Property: screen dimensions

This is only necessary for iOS < 8.0.  It is otherwise unused.  It can only be determined at runtime because of iPhone 6 and iPhone 6 plus scaling and sampling factors.

####  Property: iPhone apps emulated on iPads

On simulators, we could inspect the Info.plist and the RunLoop::Device to determine if this is an iPhone app emulated on an iPad.

On devices, we would need to used something like `ideviceinfo`.

#### Property: The version of the calabash server.

On iOS Simulators, this can be discovered before launching the app.

On device, it will not be possible _unless_ we can inspect the app bundle installed on the device before we launch.    For the calabash.framework, we could ship with an Info.plist that has the server version.  For calabash dylibs, we would need to be able to call `strings` and `grep` to get the server version.  I don't think this is possible on a physical device.

#### Property: form factor

For iOS simulators, this can be determined by inspecting the RunLoop::Device.

On devices, we'd need to something like `ideviceinfo` to determine the form factor.

#### Property: iPod?

There are no iPod simulators, so this method only makes sense on devices.

See the discussion about device form factors above.
