### PR TITLE
Remove cucumber dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
 script:
   - gem install cucumber
   - script/ci/travis/install-gem-ci.rb
-  - bundle exec rake unit
+  - rake unit
   - rake install
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.2.1
 
 script:
+  - gem install cucumber
   - script/ci/travis/install-gem-ci.rb
   - bundle exec rake unit
   - rake install

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -39,7 +39,6 @@ Public License.}
   spec.executables   = 'calabash'
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cucumber', '>= 1.3', '< 3.0'
   spec.add_dependency 'edn', '>= 1.0.6', '< 2.0'
   spec.add_dependency 'slowhandcuke', '>= 0.0.3', '< 1.0'
   spec.add_dependency 'geocoder', '>= 1.1.8', '< 2.0'

--- a/calabash.gemspec
+++ b/calabash.gemspec
@@ -40,7 +40,6 @@ Public License.}
   spec.require_paths = ['lib']
 
   spec.add_dependency 'edn', '>= 1.0.6', '< 2.0'
-  spec.add_dependency 'slowhandcuke', '>= 0.0.3', '< 1.0'
   spec.add_dependency 'geocoder', '>= 1.1.8', '< 2.0'
   spec.add_dependency 'httpclient', '~> 2.6'
   spec.add_dependency 'escape', '>= 0.0.4', '< 1.0'


### PR DESCRIPTION
### Motivation

Why do we depend on cucumber? :)

The only tool that needs this is the run-command.  Otherwise it is not necessary.

I realize we are a cucumber tool, but this change might push folks toward using a Gemfile.

At the very least, let's remove the slowhandcuke dependency _unless_ we are going to included it in the skeleton.