### PR TITLE
Generic route handling mixin by extracting methods from iOS map route

### DIFF
--- a/lib/calabash/http/error.rb
+++ b/lib/calabash/http/error.rb
@@ -3,5 +3,9 @@ module Calabash
     class Error < StandardError
 
     end
+
+    class RequestError < StandardError
+
+    end
   end
 end

--- a/lib/calabash/http/request.rb
+++ b/lib/calabash/http/request.rb
@@ -7,6 +7,33 @@ module Calabash
         @route = route
         @params = params
       end
+
+      # Create a new Request from `route` and `parameters`.
+      #
+      # @param [String] route The http route for the new request.
+      # @param [Array, Hash] parameters An Array or Hash of parameters.
+      # @return [Request] A new Request for `route` with `parameters`.
+      # @raise [RequestError] Raises an error if the parameters cannot be
+      #   converted to JSON
+      def self.request(route, parameters)
+        Request.new(route, Request.data(parameters))
+      end
+
+      private
+
+      # Converts `parameters` to JSON.
+      #
+      # @param [Array, Hash] parameters An Array or Hash of parameters.
+      # @return [String] A JSON formatted string that represents the parameters.
+      # @raise [RequestError] Raises an error if the parameters cannot be
+      #   converted to JSON
+      def self.data(parameters)
+        begin
+          JSON.generate(parameters)
+        rescue *[TypeError, JSON::GeneratorError] => e
+          raise RequestError, "#{e}: could not generate JSON from '#{parameters}'"
+        end
+      end
     end
   end
 end

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -14,12 +14,8 @@ module Calabash
       Calabash.send(:included, base)
     end
 
-    # @todo Should we restrict access to some class and modules?
-    #
-    # For example, I don't want casual users to have automatic access to the
-    # RuntimeInfo class or the MapRoute module.
-
     require 'calabash/ios/runtime_attributes'
+    require 'calabash/ios/routes/error'
     require 'calabash/ios/routes/map_route'
 
     require 'calabash/ios/environment'

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -16,6 +16,7 @@ module Calabash
 
     require 'calabash/ios/runtime_attributes'
     require 'calabash/ios/routes/error'
+    require 'calabash/ios/routes/route_mixin'
     require 'calabash/ios/routes/map_route'
 
     require 'calabash/ios/environment'

--- a/lib/calabash/ios/device.rb
+++ b/lib/calabash/ios/device.rb
@@ -5,6 +5,7 @@ module Calabash
     class Device < ::Calabash::Device
 
       include Calabash::IOS::PhysicalDeviceMixin
+      include Calabash::IOS::Routes::RouteMixin
       include Calabash::IOS::Routes::MapRoute
 
       # @todo Should these be public?

--- a/lib/calabash/ios/routes/error.rb
+++ b/lib/calabash/ios/routes/error.rb
@@ -1,0 +1,9 @@
+module Calabash
+  module IOS
+    module Routes
+      class MapRouteError < StandardError
+
+      end
+    end
+  end
+end

--- a/lib/calabash/ios/routes/map_route.rb
+++ b/lib/calabash/ios/routes/map_route.rb
@@ -13,7 +13,7 @@ module Calabash
 
         private
 
-        def parameters(query, method_name, *method_args)
+        def make_map_parameters(query, method_name, *method_args)
           {
                 :operation =>
                       {
@@ -33,7 +33,7 @@ module Calabash
         end
 
         def request(query, method_name, *method_args)
-          parameters = parameters(query, method_name, *method_args)
+          parameters = make_map_parameters(query, method_name, *method_args)
           data = data(parameters)
           Calabash::HTTP::Request.new('map', data)
         end

--- a/lib/calabash/ios/routes/map_route.rb
+++ b/lib/calabash/ios/routes/map_route.rb
@@ -6,7 +6,7 @@ module Calabash
         class MapRouteError < StandardError; end
 
         def map_route(query, method_name, *method_args)
-          request = request(query, method_name, *method_args)
+          request = make_map_request(query, method_name, *method_args)
           response = post(request)
           handle_response(response, query)
         end
@@ -24,18 +24,13 @@ module Calabash
           }
         end
 
-        def data(parameters)
-          begin
-            JSON.generate(parameters)
-          rescue TypeError => e
-            raise MapRouteError, "#{e}: could not generate JSON from '#{parameters}'"
-          end
-        end
-
-        def request(query, method_name, *method_args)
+        def make_map_request(query, method_name, *method_args)
           parameters = make_map_parameters(query, method_name, *method_args)
-          data = data(parameters)
-          Calabash::HTTP::Request.new('map', data)
+          begin
+            Calabash::HTTP::Request.request('map', parameters)
+          rescue => e
+            raise MapRouteError, e
+          end
         end
 
         def post(request)

--- a/lib/calabash/ios/routes/map_route.rb
+++ b/lib/calabash/ios/routes/map_route.rb
@@ -3,8 +3,6 @@ module Calabash
     module Routes
       module MapRoute
 
-        class MapRouteError < StandardError; end
-
         def map_route(query, method_name, *method_args)
           request = make_map_request(query, method_name, *method_args)
           response = post(request)

--- a/lib/calabash/ios/routes/route_mixin.rb
+++ b/lib/calabash/ios/routes/route_mixin.rb
@@ -1,0 +1,58 @@
+module Calabash
+  module IOS
+    module Routes
+      module RouteMixin
+
+        private
+
+        def route_post_request(request, error_class)
+          begin
+            http_client.post(request)
+          rescue => e
+            raise error_class, e
+          end
+        end
+
+        def route_handle_response(response, query, error_class)
+          body = response.body
+          begin
+            hash = JSON.parse(body)
+          rescue TypeError, JSON::ParserError => e
+            raise error_class, "Could not parse response '#{body}: #{e}'"
+          end
+
+          outcome = hash['outcome']
+
+          case outcome
+            when 'FAILURE'
+              route_failure(hash, query, error_class)
+            when 'SUCCESS'
+              route_success(hash, query)
+            else
+              raise error_class, "Server responded with an invalid outcome: '#{hash['outcome']}'"
+          end
+        end
+
+        def route_failure(hash, query, error_class)
+
+          fetch_value = lambda do |key|
+            value = hash[key]
+            if value.nil? || value.empty?
+              'unknown'
+            else
+              value
+            end
+          end
+
+          reason = fetch_value.call('reason')
+          details = fetch_value.call('details')
+          raise error_class, "Map failed reason: '#{reason}' details: '#{details}' for query '#{query}'"
+        end
+
+        def route_success(hash, query)
+          Calabash::QueryResult.create(hash['results'], query)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -1,0 +1,59 @@
+describe Calabash::HTTP::Request do
+
+  subject { Calabash::HTTP::Request }
+
+  let (:error) {Calabash::HTTP::RequestError}
+
+  describe '.data' do
+    describe 'raises errors when' do
+      let(:parameters) { 'bad' }
+      it 'JSON.generate raises GeneratorError' do
+        expect(JSON).to receive(:generate).with(parameters).and_raise JSON::GeneratorError
+        expect do
+          subject.send(:data, parameters)
+        end.to raise_error error
+      end
+
+      it 'JSON.generate raise TypeError' do
+        expect(JSON).to receive(:generate).with(parameters).and_raise TypeError
+        expect do
+          subject.send(:data, parameters)
+        end.to raise_error error
+      end
+    end
+
+    describe 'returns JSON when' do
+      it 'is passed an Array' do
+        parameters = [1, 2, 3]
+        actual = subject.send(:data, parameters)
+        expect(actual).to be == '[1,2,3]'
+      end
+
+      it 'is passed a Hash' do
+        parameters = {:offset => {:x => 0, :y => 0}}
+        actual = Calabash::HTTP::Request.send(:data, parameters)
+        expect(actual).to be == "{\"offset\":{\"x\":0,\"y\":0}}"
+      end
+    end
+  end
+
+  describe '.request' do
+
+    let(:parameters) { {} }
+
+    it 'raises an error if the parameters cannot be converted to JSON' do
+      expect(subject).to receive(:data).with(parameters).and_raise error
+      expect do
+        subject.request('query', parameters)
+      end.to raise_error error
+    end
+
+    it 'creates a route' do
+      expect(subject).to receive(:data).with(parameters).and_return('{}')
+      actual = subject.request('query', parameters)
+      expect(actual).to be_a_kind_of(subject)
+      expect(actual.route).to be == 'query'
+      expect(actual.params).to be == '{}'
+    end
+  end
+end

--- a/spec/lib/ios/routes/map_route_spec.rb
+++ b/spec/lib/ios/routes/map_route_spec.rb
@@ -26,7 +26,7 @@ describe Calabash::IOS::Routes::MapRoute do
                       },
                 :query => 'query'
           }
-    expect(route.send(:parameters,'query', 'name', 'args')).to be == expected
+    expect(route.send(:make_map_parameters, 'query', 'name', 'args')).to be == expected
   end
 
   describe '#data' do
@@ -45,7 +45,7 @@ describe Calabash::IOS::Routes::MapRoute do
   end
 
   it '#request' do
-    expect(route).to receive(:parameters).with('query', 'name', 'args').and_return({})
+    expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
     expect(route).to receive(:data).with({}).and_return 'JSON'
     request = route.send(:request, 'query', 'name', 'args')
     expect(request).to be_a_kind_of Calabash::HTTP::Request

--- a/spec/lib/ios/routes/map_route_spec.rb
+++ b/spec/lib/ios/routes/map_route_spec.rb
@@ -1,5 +1,7 @@
 describe Calabash::IOS::Routes::MapRoute do
 
+  let(:route_error) { Calabash::IOS::Routes::MapRouteError }
+
   let(:route) do
     Class.new do
       include Calabash::IOS::Routes::MapRoute
@@ -43,7 +45,7 @@ describe Calabash::IOS::Routes::MapRoute do
       expect(Calabash::HTTP::Request).to receive(:request).and_raise StandardError
       expect do
         route.send(:make_map_request, 'query', 'name', 'args')
-      end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+      end.to raise_error route_error
     end
   end
 
@@ -64,21 +66,21 @@ describe Calabash::IOS::Routes::MapRoute do
         expect(JSON).to receive(:parse).with(body).and_raise TypeError
         expect do
           route.send(:handle_response, response, 'query')
-        end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+        end.to raise_error route_error
       end
 
       it 'parsing body raises JSON::ParseError' do
         expect(JSON).to receive(:parse).with(body).and_raise JSON::ParserError
         expect do
           route.send(:handle_response, response, 'query')
-        end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+        end.to raise_error route_error
       end
 
       it 'parsed body outcome key value is not SUCCESS or FAILURE' do
         expect(JSON).to receive(:parse).with(body).and_return({'outcome' => 'invalid value'})
         expect do
           route.send(:handle_response, response, 'query')
-        end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+        end.to raise_error route_error
       end
     end
 
@@ -92,10 +94,10 @@ describe Calabash::IOS::Routes::MapRoute do
     it "calls 'failure' when outcome is 'FAILURE'" do
       hash = {'outcome' => 'FAILURE'}
       expect(JSON).to receive(:parse).with(body).and_return(hash)
-      expect(route).to receive(:failure).with(hash, 'query').and_raise Calabash::IOS::Routes::MapRoute::MapRouteError
+      expect(route).to receive(:failure).with(hash, 'query').and_raise route_error
       expect do
         route.send(:handle_response, response, 'query')
-      end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+      end.to raise_error route_error
     end
   end
 
@@ -103,23 +105,23 @@ describe Calabash::IOS::Routes::MapRoute do
   it '#failure' do
     expect do
       route.send(:failure, {}, 'query')
-    end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+    end.to raise_error route_error
 
     expect do
       route.send(:failure, {'reason' => 'reason'}, 'query')
-    end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+    end.to raise_error route_error
 
     expect do
       route.send(:failure, {'reason' => ''}, 'query')
-    end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+    end.to raise_error route_error
 
     expect do
       route.send(:failure, {'details' => 'details'}, 'query')
-    end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+    end.to raise_error route_error
 
     expect do
       route.send(:failure, {'details' => ''}, 'query')
-    end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
+    end.to raise_error route_error
   end
 
   it '#success' do

--- a/spec/lib/ios/routes/map_route_spec.rb
+++ b/spec/lib/ios/routes/map_route_spec.rb
@@ -29,28 +29,22 @@ describe Calabash::IOS::Routes::MapRoute do
     expect(route.send(:make_map_parameters, 'query', 'name', 'args')).to be == expected
   end
 
-  describe '#data' do
-    let(:parameters) { {} }
-    it 'raises error if JSON.generate raises TypeError' do
-      expect(JSON).to receive(:generate).with(parameters).and_raise TypeError
+  describe '#make_map_request' do
+    it "makes a 'map' request" do
+      expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
+      request = route.send(:make_map_request, 'query', 'name', 'args')
+      expect(request).to be_a_kind_of Calabash::HTTP::Request
+      expect(request.route).to be == 'map'
+      expect(request.params).to be == '{}'
+    end
+
+    it 'raises an error if a request cannot be made' do
+      expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
+      expect(Calabash::HTTP::Request).to receive(:request).and_raise StandardError
       expect do
-        route.send(:data, parameters)
-      end.to raise_error
+        route.send(:make_map_request, 'query', 'name', 'args')
+      end.to raise_error Calabash::IOS::Routes::MapRoute::MapRouteError
     end
-
-    it 'it generates JSON from parameters' do
-      expect(JSON).to receive(:generate).with(parameters).and_return 'JSON'
-      expect(route.send(:data, parameters)).to be == 'JSON'
-    end
-  end
-
-  it '#request' do
-    expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
-    expect(route).to receive(:data).with({}).and_return 'JSON'
-    request = route.send(:request, 'query', 'name', 'args')
-    expect(request).to be_a_kind_of Calabash::HTTP::Request
-    expect(request.route).to be == 'map'
-    expect(request.params).to be == 'JSON'
   end
 
   it '#post' do

--- a/spec/lib/ios/routes/map_route_spec.rb
+++ b/spec/lib/ios/routes/map_route_spec.rb
@@ -2,13 +2,10 @@ describe Calabash::IOS::Routes::MapRoute do
 
   let(:route_error) { Calabash::IOS::Routes::MapRouteError }
 
-  let(:route) do
+  let(:device) do
     Class.new do
+      include Calabash::IOS::Routes::RouteMixin
       include Calabash::IOS::Routes::MapRoute
-      attr_reader :http_client
-      @http_client =  Class.new do
-        def post(_, _); ; end
-      end.new
     end.new
   end
 
@@ -28,107 +25,55 @@ describe Calabash::IOS::Routes::MapRoute do
                       },
                 :query => 'query'
           }
-    expect(route.send(:make_map_parameters, 'query', 'name', 'args')).to be == expected
+    expect(device.send(:make_map_parameters, 'query', 'name', 'args')).to be == expected
   end
 
   describe '#make_map_request' do
     it "makes a 'map' request" do
-      expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
-      request = route.send(:make_map_request, 'query', 'name', 'args')
+      expect(device).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
+      request = device.send(:make_map_request, 'query', 'name', 'args')
       expect(request).to be_a_kind_of Calabash::HTTP::Request
       expect(request.route).to be == 'map'
       expect(request.params).to be == '{}'
     end
 
     it 'raises an error if a request cannot be made' do
-      expect(route).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
+      expect(device).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
       expect(Calabash::HTTP::Request).to receive(:request).and_raise StandardError
       expect do
-        route.send(:make_map_request, 'query', 'name', 'args')
+        device.send(:make_map_request, 'query', 'name', 'args')
       end.to raise_error route_error
     end
   end
 
-  it '#post' do
-    request = Calabash::HTTP::Request.new('map', 'JSON')
-    expect(route.http_client).to receive(:post).with(request).and_return 'response'
-    expect(route.send(:post, request)).to be == 'response'
-  end
+  describe '#map_route' do
+    describe 'raises MapRouteError when' do
 
-  describe '#handle_response' do
+      it 'posting the request raises an error' do
+        expect(device).to receive(:make_map_request).and_return 'request'
+        expect(device).to receive(:route_post_request).with('request', route_error).and_raise route_error
 
-    let(:body) { {} }
-
-    before { expect(response).to receive(:body).and_return(body) }
-
-    describe 'raises errors if' do
-      it 'parsing body raises TypeError' do
-        expect(JSON).to receive(:parse).with(body).and_raise TypeError
         expect do
-          route.send(:handle_response, response, 'query')
+          device.map_route('query', 'name', 'args')
         end.to raise_error route_error
       end
 
-      it 'parsing body raises JSON::ParseError' do
-        expect(JSON).to receive(:parse).with(body).and_raise JSON::ParserError
-        expect do
-          route.send(:handle_response, response, 'query')
-        end.to raise_error route_error
-      end
+      it 'handling the response raises an error' do
+        expect(device).to receive(:make_map_request).and_return 'request'
+        expect(device).to receive(:route_post_request).with('request', route_error).and_return 'result'
+        expect(device).to receive(:route_handle_response).with('result', 'query', route_error).and_raise route_error
 
-      it 'parsed body outcome key value is not SUCCESS or FAILURE' do
-        expect(JSON).to receive(:parse).with(body).and_return({'outcome' => 'invalid value'})
         expect do
-          route.send(:handle_response, response, 'query')
+          device.map_route('query', 'name', 'args')
         end.to raise_error route_error
       end
     end
 
-    it "calls 'success' when outcome is 'SUCCESS'" do
-      hash = {'outcome' => 'SUCCESS'}
-      expect(JSON).to receive(:parse).with(body).and_return(hash)
-      expect(route).to receive(:success).with(hash, 'query').and_return 'query results'
-      expect(route.send(:handle_response, response, 'query')).to be == 'query results'
+    it "makes an http call to the 'map' route" do
+      expect(device).to receive(:make_map_request).and_return 'request'
+      expect(device).to receive(:route_post_request).with('request', route_error).and_return 'result'
+      expect(device).to receive(:route_handle_response).with('result', 'query', route_error).and_return []
+      expect(device.map_route('query', 'name', 'args')).to be == []
     end
-
-    it "calls 'failure' when outcome is 'FAILURE'" do
-      hash = {'outcome' => 'FAILURE'}
-      expect(JSON).to receive(:parse).with(body).and_return(hash)
-      expect(route).to receive(:failure).with(hash, 'query').and_raise route_error
-      expect do
-        route.send(:handle_response, response, 'query')
-      end.to raise_error route_error
-    end
-  end
-
-
-  it '#failure' do
-    expect do
-      route.send(:failure, {}, 'query')
-    end.to raise_error route_error
-
-    expect do
-      route.send(:failure, {'reason' => 'reason'}, 'query')
-    end.to raise_error route_error
-
-    expect do
-      route.send(:failure, {'reason' => ''}, 'query')
-    end.to raise_error route_error
-
-    expect do
-      route.send(:failure, {'details' => 'details'}, 'query')
-    end.to raise_error route_error
-
-    expect do
-      route.send(:failure, {'details' => ''}, 'query')
-    end.to raise_error route_error
-  end
-
-  it '#success' do
-    hash = {'results' => []}
-    actual = route.send(:success, hash, 'query')
-    expect(actual).to be_a_kind_of Calabash::QueryResult
-    expect(actual.query).to be == 'query'
-    expect(actual).to be == []
   end
 end

--- a/spec/lib/ios/routes/route_mixin_spec.rb
+++ b/spec/lib/ios/routes/route_mixin_spec.rb
@@ -1,0 +1,123 @@
+describe Calabash::IOS::Routes::RouteMixin do
+
+  let(:error_class) { Class.new(StandardError) }
+
+  let(:device) do
+    Class.new do
+      include Calabash::IOS::Routes::RouteMixin
+
+      attr_reader :http_client
+
+      def initialize
+        @http_client = Class.new do
+          def post(_); ; end;
+        end.new
+      end
+    end.new
+  end
+
+  let(:response) do
+    Class.new do
+      def body; ; ; end
+    end.new
+  end
+
+  describe '#route_post_request' do
+    it 'calls http_client.post' do
+      expect(device.http_client).to receive(:post).with('request').and_return 'response'
+
+      expect(device.send(:route_post_request, 'request', error_class)).to be == 'response'
+    end
+
+    it 're-raises error with error_class' do
+      expect(device.http_client).to receive(:post).with('request').and_raise ArgumentError
+
+      expect do
+        device.send(:route_post_request, 'request', error_class)
+      end.to raise_error error_class
+    end
+  end
+
+  describe '#route_handle_response' do
+
+    let(:body) { {} }
+
+    before { expect(response).to receive(:body).and_return(body) }
+
+    describe 'raises errors if' do
+      it 'parsing body raises TypeError' do
+        expect(JSON).to receive(:parse).with(body).and_raise TypeError
+
+        expect do
+          device.send(:route_handle_response, response, 'query', error_class)
+        end.to raise_error error_class
+      end
+
+      it 'parsing body raises JSON::ParseError' do
+        expect(JSON).to receive(:parse).with(body).and_raise JSON::ParserError
+
+        expect do
+          device.send(:route_handle_response, response, 'query', error_class)
+        end.to raise_error error_class
+      end
+
+      it 'parsed body outcome key value is not SUCCESS or FAILURE' do
+        expect(JSON).to receive(:parse).with(body).and_return({'outcome' =>
+                                                                     'invalid value'})
+        expect do
+          device.send(:route_handle_response, response, 'query', error_class)
+        end.to raise_error error_class
+      end
+    end
+
+    it "calls 'success' when outcome is 'SUCCESS'" do
+      hash = {'outcome' => 'SUCCESS'}
+      expect(JSON).to receive(:parse).with(body).and_return(hash)
+      expect(device).to receive(:route_success).with(hash, 'query').and_return 'query results'
+
+      actual = device.send(:route_handle_response, response, 'query', error_class)
+      expect(actual).to be == 'query results'
+    end
+
+    it "calls 'failure' when outcome is 'FAILURE'" do
+      hash = {'outcome' => 'FAILURE'}
+      expect(JSON).to receive(:parse).with(body).and_return(hash)
+      expect(device).to receive(:route_failure).with(hash, 'query', error_class).and_raise error_class
+
+      expect do
+        device.send(:route_handle_response, response, 'query', error_class)
+      end.to raise_error error_class
+    end
+  end
+
+
+  it '#route_failure' do
+    expect do
+      device.send(:route_failure, {}, 'query', error_class)
+    end.to raise_error error_class
+
+    expect do
+      device.send(:route_failure, {'reason' => 'reason'}, 'query', error_class)
+    end.to raise_error error_class
+
+    expect do
+      device.send(:route_failure, {'reason' => ''}, 'query', error_class)
+    end.to raise_error error_class
+
+    expect do
+      device.send(:route_failure, {'details' => 'details'}, 'query', error_class)
+    end.to raise_error error_class
+
+    expect do
+      device.send(:route_failure, {'details' => ''}, 'query', error_class)
+    end.to raise_error error_class
+  end
+
+  it '#route_success' do
+    hash = {'results' => []}
+    actual = device.send(:route_success, hash, 'query')
+    expect(actual).to be_a_kind_of Calabash::QueryResult
+    expect(actual.query).to be == 'query'
+    expect(actual).to be == []
+  end
+end


### PR DESCRIPTION
### Motivation

After looking at the UIA route and the map route, I decided there was enough duplication that I should extract into generic methods.

@TobiasRoikjer Do you think you will be able to reuse this on the Android side?