### PR TITLE
Refactor RouteMixin with Tobias's edits

### DIFF
--- a/lib/calabash/ios/routes/error.rb
+++ b/lib/calabash/ios/routes/error.rb
@@ -1,9 +1,7 @@
 module Calabash
   module IOS
     module Routes
-      class MapRouteError < StandardError
-
-      end
+      class RouteError < StandardError;  end
     end
   end
 end

--- a/lib/calabash/ios/routes/map_route.rb
+++ b/lib/calabash/ios/routes/map_route.rb
@@ -5,8 +5,8 @@ module Calabash
 
         def map_route(query, method_name, *method_args)
           request = make_map_request(query, method_name, *method_args)
-          response = route_post_request(request, MapRouteError)
-          route_handle_response(response, query, MapRouteError)
+          response = route_post_request(request)
+          route_handle_response(response, query)
         end
 
         private
@@ -27,7 +27,7 @@ module Calabash
           begin
             Calabash::HTTP::Request.request('map', parameters)
           rescue => e
-            raise MapRouteError, e
+            raise RouteError, e
           end
         end
       end

--- a/lib/calabash/ios/routes/route_mixin.rb
+++ b/lib/calabash/ios/routes/route_mixin.rb
@@ -5,35 +5,35 @@ module Calabash
 
         private
 
-        def route_post_request(request, error_class)
+        def route_post_request(request)
           begin
             http_client.post(request)
           rescue => e
-            raise error_class, e
+            raise RouteError, e
           end
         end
 
-        def route_handle_response(response, query, error_class)
+        def route_handle_response(response, query)
           body = response.body
           begin
             hash = JSON.parse(body)
           rescue TypeError, JSON::ParserError => e
-            raise error_class, "Could not parse response '#{body}: #{e}'"
+            raise RouteError, "Could not parse response '#{body}: #{e}'"
           end
 
           outcome = hash['outcome']
 
           case outcome
             when 'FAILURE'
-              route_failure(hash, query, error_class)
+              route_failure(hash, query)
             when 'SUCCESS'
               route_success(hash, query)
             else
-              raise error_class, "Server responded with an invalid outcome: '#{hash['outcome']}'"
+              raise RouteError, "Server responded with an invalid outcome: '#{hash['outcome']}'"
           end
         end
 
-        def route_failure(hash, query, error_class)
+        def route_failure(hash, query)
 
           fetch_value = lambda do |key|
             value = hash[key]
@@ -46,7 +46,7 @@ module Calabash
 
           reason = fetch_value.call('reason')
           details = fetch_value.call('details')
-          raise error_class, "Map failed reason: '#{reason}' details: '#{details}' for query '#{query}'"
+          raise RouteError, "Map failed reason: '#{reason}' details: '#{details}' for query '#{query}'"
         end
 
         def route_success(hash, query)

--- a/spec/lib/ios/routes/map_route_spec.rb
+++ b/spec/lib/ios/routes/map_route_spec.rb
@@ -1,6 +1,6 @@
 describe Calabash::IOS::Routes::MapRoute do
 
-  let(:route_error) { Calabash::IOS::Routes::MapRouteError }
+  let(:route_error) { Calabash::IOS::Routes::RouteError }
 
   let(:device) do
     Class.new do
@@ -31,6 +31,7 @@ describe Calabash::IOS::Routes::MapRoute do
   describe '#make_map_request' do
     it "makes a 'map' request" do
       expect(device).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
+
       request = device.send(:make_map_request, 'query', 'name', 'args')
       expect(request).to be_a_kind_of Calabash::HTTP::Request
       expect(request.route).to be == 'map'
@@ -40,6 +41,7 @@ describe Calabash::IOS::Routes::MapRoute do
     it 'raises an error if a request cannot be made' do
       expect(device).to receive(:make_map_parameters).with('query', 'name', 'args').and_return({})
       expect(Calabash::HTTP::Request).to receive(:request).and_raise StandardError
+
       expect do
         device.send(:make_map_request, 'query', 'name', 'args')
       end.to raise_error route_error
@@ -51,7 +53,7 @@ describe Calabash::IOS::Routes::MapRoute do
 
       it 'posting the request raises an error' do
         expect(device).to receive(:make_map_request).and_return 'request'
-        expect(device).to receive(:route_post_request).with('request', route_error).and_raise route_error
+        expect(device).to receive(:route_post_request).with('request').and_raise route_error
 
         expect do
           device.map_route('query', 'name', 'args')
@@ -60,8 +62,8 @@ describe Calabash::IOS::Routes::MapRoute do
 
       it 'handling the response raises an error' do
         expect(device).to receive(:make_map_request).and_return 'request'
-        expect(device).to receive(:route_post_request).with('request', route_error).and_return 'result'
-        expect(device).to receive(:route_handle_response).with('result', 'query', route_error).and_raise route_error
+        expect(device).to receive(:route_post_request).with('request').and_return 'result'
+        expect(device).to receive(:route_handle_response).with('result', 'query').and_raise route_error
 
         expect do
           device.map_route('query', 'name', 'args')
@@ -71,8 +73,9 @@ describe Calabash::IOS::Routes::MapRoute do
 
     it "makes an http call to the 'map' route" do
       expect(device).to receive(:make_map_request).and_return 'request'
-      expect(device).to receive(:route_post_request).with('request', route_error).and_return 'result'
-      expect(device).to receive(:route_handle_response).with('result', 'query', route_error).and_return []
+      expect(device).to receive(:route_post_request).with('request').and_return 'result'
+      expect(device).to receive(:route_handle_response).with('result', 'query').and_return []
+
       expect(device.map_route('query', 'name', 'args')).to be == []
     end
   end

--- a/spec/lib/ios/routes/route_mixin_spec.rb
+++ b/spec/lib/ios/routes/route_mixin_spec.rb
@@ -1,6 +1,6 @@
 describe Calabash::IOS::Routes::RouteMixin do
 
-  let(:error_class) { Class.new(StandardError) }
+  let(:error_class) { Calabash::IOS::Routes::RouteError }
 
   let(:device) do
     Class.new do
@@ -26,14 +26,14 @@ describe Calabash::IOS::Routes::RouteMixin do
     it 'calls http_client.post' do
       expect(device.http_client).to receive(:post).with('request').and_return 'response'
 
-      expect(device.send(:route_post_request, 'request', error_class)).to be == 'response'
+      expect(device.send(:route_post_request, 'request')).to be == 'response'
     end
 
-    it 're-raises error with error_class' do
+    it "does not re-raise errors raised by 'post'" do
       expect(device.http_client).to receive(:post).with('request').and_raise ArgumentError
 
       expect do
-        device.send(:route_post_request, 'request', error_class)
+        device.send(:route_post_request, 'request')
       end.to raise_error error_class
     end
   end
@@ -49,7 +49,7 @@ describe Calabash::IOS::Routes::RouteMixin do
         expect(JSON).to receive(:parse).with(body).and_raise TypeError
 
         expect do
-          device.send(:route_handle_response, response, 'query', error_class)
+          device.send(:route_handle_response, response, 'query')
         end.to raise_error error_class
       end
 
@@ -57,7 +57,7 @@ describe Calabash::IOS::Routes::RouteMixin do
         expect(JSON).to receive(:parse).with(body).and_raise JSON::ParserError
 
         expect do
-          device.send(:route_handle_response, response, 'query', error_class)
+          device.send(:route_handle_response, response, 'query')
         end.to raise_error error_class
       end
 
@@ -65,7 +65,7 @@ describe Calabash::IOS::Routes::RouteMixin do
         expect(JSON).to receive(:parse).with(body).and_return({'outcome' =>
                                                                      'invalid value'})
         expect do
-          device.send(:route_handle_response, response, 'query', error_class)
+          device.send(:route_handle_response, response, 'query')
         end.to raise_error error_class
       end
     end
@@ -75,17 +75,17 @@ describe Calabash::IOS::Routes::RouteMixin do
       expect(JSON).to receive(:parse).with(body).and_return(hash)
       expect(device).to receive(:route_success).with(hash, 'query').and_return 'query results'
 
-      actual = device.send(:route_handle_response, response, 'query', error_class)
+      actual = device.send(:route_handle_response, response, 'query')
       expect(actual).to be == 'query results'
     end
 
     it "calls 'failure' when outcome is 'FAILURE'" do
       hash = {'outcome' => 'FAILURE'}
       expect(JSON).to receive(:parse).with(body).and_return(hash)
-      expect(device).to receive(:route_failure).with(hash, 'query', error_class).and_raise error_class
+      expect(device).to receive(:route_failure).with(hash, 'query').and_raise error_class
 
       expect do
-        device.send(:route_handle_response, response, 'query', error_class)
+        device.send(:route_handle_response, response, 'query')
       end.to raise_error error_class
     end
   end
@@ -93,23 +93,23 @@ describe Calabash::IOS::Routes::RouteMixin do
 
   it '#route_failure' do
     expect do
-      device.send(:route_failure, {}, 'query', error_class)
+      device.send(:route_failure, {}, 'query')
     end.to raise_error error_class
 
     expect do
-      device.send(:route_failure, {'reason' => 'reason'}, 'query', error_class)
+      device.send(:route_failure, {'reason' => 'reason'}, 'query')
     end.to raise_error error_class
 
     expect do
-      device.send(:route_failure, {'reason' => ''}, 'query', error_class)
+      device.send(:route_failure, {'reason' => ''}, 'query')
     end.to raise_error error_class
 
     expect do
-      device.send(:route_failure, {'details' => 'details'}, 'query', error_class)
+      device.send(:route_failure, {'details' => 'details'}, 'query')
     end.to raise_error error_class
 
     expect do
-      device.send(:route_failure, {'details' => ''}, 'query', error_class)
+      device.send(:route_failure, {'details' => ''}, 'query')
     end.to raise_error error_class
   end
 


### PR DESCRIPTION
### Motivation

Replaces error classes for specific routes with a generic RouteError.

I opted to keep the Mixin name for now.