### PR TITLE
Wait#wait_for should use default timeout

### DIFF
--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -120,8 +120,9 @@ module Calabash
     # @option options [Boolean] :screenshot_on_error (true) Take a screenshot
     #  if the block fails to be truthy or an error is raised in the block.
     # @return The returned value of `block` if it is truthy
-    def wait_for(timeout, timeout_message, options={}, &block)
+    def wait_for(timeout_message, options={}, &block)
       wait_options = Wait.default_options.merge(options)
+      timeout = wait_options[:timeout]
 
       with_timeout(timeout, timeout_message, wait_options[:exception_class]) do
         loop do
@@ -154,9 +155,10 @@ module Calabash
 
       timeout_options = defaults.merge(options)
 
-      wait_for(timeout_options[:timeout], timeout_options[:message],
-                {exception_class: timeout_options[:exception_class],
-                 retry_frequency: timeout_options[:retry_frequency]}) do
+      wait_for(timeout_options[:message],
+               {timeout: timeout_options[:timeout],
+                exception_class: timeout_options[:exception_class],
+                retry_frequency: timeout_options[:retry_frequency]}) do
         view_exists?(query)
       end.first
     end

--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -107,10 +107,11 @@ module Calabash
     # If the block does not evaluate to truthy within the given timeout
     # an TimeoutError will be raised.
     #
-    # The default timeout will be `Environment::WAIT_TIMEOUT`.
+    # The default timeout will be `Wait.default_options[:timeout]`.
     #
     # @see Calabash::Wait#with_timeout
     # @see Calabash::Environment::WAIT_TIMEOUT
+    # @see Calabash::Wait.default_options
     #
     # @param [String, Proc] timeout_message The error message if timed out.
     # @param [Hash] options Used to control the behavior of the wait.

--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -103,12 +103,22 @@ module Calabash
 
     # Evaluates the given block until the block evaluates to truthy. If the
     # block raises an error, it is **not** rescued.
-    # If the block does not evaluate to truthy within the given `timeout`
+    #
+    # If the block does not evaluate to truthy within the given timeout
     # an TimeoutError will be raised.
     #
-    # @param [Number] timeout The time before failing
-    # @param [String, Proc] timeout_message The error message if timed out
+    # The default timeout will be `Environment::WAIT_TIMEOUT`.
+    #
     # @see Calabash::Wait#with_timeout
+    # @see Calabash::Environment::WAIT_TIMEOUT
+    #
+    # @param [String, Proc] timeout_message The error message if timed out.
+    # @param [Hash] options Used to control the behavior of the wait.
+    # @option options [Number] :timeout (30) How long to wait before timing out.
+    # @option options [Number] :retry_frequency (0.3) How often to check for
+    #  the condition block to be truthy.
+    # @option options [Boolean] :screenshot_on_error (true) Take a screenshot
+    #  if the block fails to be truthy or an error is raised in the block.
     # @return The returned value of `block` if it is truthy
     def wait_for(timeout, timeout_message, options={}, &block)
       wait_options = Wait.default_options.merge(options)

--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -186,8 +186,9 @@ module Calabash
 
       timeout_options = defaults.merge(options)
 
-      wait_for(timeout_options[:timeout], timeout_options[:message],
-               {exception_class: timeout_options[:exception_class],
+      wait_for(timeout_options[:message],
+               {timeout: timeout_options[:timeout],
+                exception_class: timeout_options[:exception_class],
                 retry_frequency: timeout_options[:retry_frequency]}) do
         views_exist?(queries)
       end
@@ -215,8 +216,9 @@ module Calabash
 
       timeout_options = defaults.merge(options)
 
-      wait_for(timeout_options[:timeout], timeout_options[:message],
-               {exception_class: timeout_options[:exception_class],
+      wait_for(timeout_options[:message],
+               {timeout: timeout_options[:timeout],
+                exception_class: timeout_options[:exception_class],
                 retry_frequency: timeout_options[:retry_frequency]}) do
         !view_exists?(query)
       end
@@ -244,8 +246,9 @@ module Calabash
 
       timeout_options = defaults.merge(options)
 
-      wait_for(timeout_options[:timeout], timeout_options[:message],
-               {exception_class: timeout_options[:exception_class],
+      wait_for(timeout_options[:message],
+               {timeout: timeout_options[:timeout],
+                exception_class: timeout_options[:exception_class],
                 retry_frequency: timeout_options[:retry_frequency]}) do
         !views_exist?(queries)
       end

--- a/spec/lib/wait_spec.rb
+++ b/spec/lib/wait_spec.rb
@@ -112,7 +112,7 @@ describe Calabash::Wait do
 
       expect(dummy).to receive(:with_timeout).with(10, 'msg', my_error)
 
-      dummy.wait_for(10, 'msg', exception_class: my_error, retry_frequency: 0)
+      dummy.wait_for('msg', timeout: 10, exception_class: my_error, retry_frequency: 0)
     end
 
     it 'should invoke the block given in with_timeout continuously until it returns truthy' do
@@ -128,7 +128,7 @@ describe Calabash::Wait do
 
       expect(dummy).to receive(:test).exactly(10).times.and_call_original
 
-      dummy.wait_for(10, 'msg', exception_class: my_error, retry_frequency: 0) do
+      dummy.wait_for('msg', timeout: 10, exception_class: my_error, retry_frequency: 0) do
         dummy.test
       end
     end
@@ -147,7 +147,7 @@ describe Calabash::Wait do
       expect(dummy).to receive(:test).exactly(10).times.and_call_original
       expect(dummy).to receive(:sleep).exactly(9).times.with(2)
 
-      dummy.wait_for(10, 'msg', exception_class: my_error, retry_frequency: 2) do
+      dummy.wait_for('msg', timeout: 10, exception_class: my_error, retry_frequency: 2) do
         dummy.test
       end
     end
@@ -168,7 +168,7 @@ describe Calabash::Wait do
       expect(dummy).to receive(:test).exactly(10).times.and_call_original
       expect(dummy).to receive(:sleep).exactly(9).times.with(5)
 
-      dummy.wait_for(10, 'msg') do
+      dummy.wait_for('msg', timeout: 10) do
         dummy.test
       end
     end
@@ -176,7 +176,7 @@ describe Calabash::Wait do
     it 'should return the value of the block given' do
       dummy.define_singleton_method(:test) {'truthy'}
 
-      expect(dummy.wait_for(10, 'msg') do
+      expect(dummy.wait_for('msg', timeout: 10) do
         dummy.test
       end).to eq('truthy')
     end
@@ -442,8 +442,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:view_exists?).with(query).and_return([{}])
-      expect(dummy).to receive(:wait_for).with(default_options[:timeout], anything,
-                                               {exception_class: Calabash::Wait::ViewNotFoundError,
+      expect(dummy).to receive(:wait_for).with(anything,
+                                               {timeout: default_options[:timeout],
+                                                exception_class: Calabash::Wait::ViewNotFoundError,
                                                 retry_frequency: default_options[:retry_frequency]}).and_call_original
 
       dummy.wait_for_view(query)
@@ -459,8 +460,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:view_exists?).with(query).and_return([{}])
-      expect(dummy).to receive(:wait_for).with(timeout, message,
-                                               {exception_class: exception_class,
+      expect(dummy).to receive(:wait_for).with(message,
+                                               {timeout: timeout,
+                                                exception_class: exception_class,
                                                 retry_frequency: retry_frequency}).and_call_original
 
       dummy.wait_for_view(query, timeout: timeout, message: message,
@@ -532,8 +534,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:views_exist?).with([query]).and_return([[{}]])
-      expect(dummy).to receive(:wait_for).with(default_options[:timeout], anything,
-                                               {exception_class: Calabash::Wait::ViewNotFoundError,
+      expect(dummy).to receive(:wait_for).with(anything,
+                                               {timeout: default_options[:timeout],
+                                                exception_class: Calabash::Wait::ViewNotFoundError,
                                                 retry_frequency: default_options[:retry_frequency]}).and_call_original
 
       dummy.wait_for_views(query)
@@ -549,8 +552,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:views_exist?).with([query]).and_return([[{}]])
-      expect(dummy).to receive(:wait_for).with(timeout, message,
-                                               {exception_class: exception_class,
+      expect(dummy).to receive(:wait_for).with(message,
+                                               {timeout: timeout,
+                                                exception_class: exception_class,
                                                 retry_frequency: retry_frequency}).and_call_original
 
       dummy.wait_for_views(query, timeout: timeout, message: message,
@@ -589,8 +593,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:view_exists?).with(query).and_return(false)
-      expect(dummy).to receive(:wait_for).with(default_options[:timeout], anything,
-                                               {exception_class: Calabash::Wait::ViewFoundError,
+      expect(dummy).to receive(:wait_for).with(anything,
+                                               {timeout: default_options[:timeout],
+                                                exception_class: Calabash::Wait::ViewFoundError,
                                                 retry_frequency: default_options[:retry_frequency]}).and_call_original
 
       dummy.wait_for_no_view(query)
@@ -606,8 +611,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:view_exists?).with(query).and_return(false)
-      expect(dummy).to receive(:wait_for).with(timeout, message,
-                                               {exception_class: exception_class,
+      expect(dummy).to receive(:wait_for).with(message,
+                                               {timeout: timeout,
+                                                exception_class: exception_class,
                                                 retry_frequency: retry_frequency}).and_call_original
 
       dummy.wait_for_no_view(query, timeout: timeout, message: message,
@@ -669,8 +675,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:views_exist?).with([query]).and_return(false)
-      expect(dummy).to receive(:wait_for).with(default_options[:timeout], anything,
-                                               {exception_class: Calabash::Wait::ViewFoundError,
+      expect(dummy).to receive(:wait_for).with(anything,
+                                               {timeout: default_options[:timeout],
+                                                exception_class: Calabash::Wait::ViewFoundError,
                                                 retry_frequency: default_options[:retry_frequency]}).and_call_original
 
       dummy.wait_for_no_views(query)
@@ -686,8 +693,9 @@ describe Calabash::Wait do
 
       expect(dummy).not_to receive(:sleep)
       expect(dummy).to receive(:views_exist?).with([query]).and_return(false)
-      expect(dummy).to receive(:wait_for).with(timeout, message,
-                                               {exception_class: exception_class,
+      expect(dummy).to receive(:wait_for).with(message,
+                                               {timeout: timeout,
+                                                exception_class: exception_class,
                                                 retry_frequency: retry_frequency}).and_call_original
 
       dummy.wait_for_no_views(query, timeout: timeout, message: message,


### PR DESCRIPTION
### Motivation

**Wait::wait_for arguments seem wrong - the timeout parameter should come from the defaults.** #103

