### PR TITLE
Rename operations.rb to app_life_cycle.rb

### DIFF
--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -5,7 +5,7 @@ module Calabash
   require 'calabash/color'
   require 'calabash/utility'
   require 'calabash/application'
-  require 'calabash/operations'
+  require 'calabash/app_life_cycle'
   require 'calabash/managed'
   require 'calabash/device'
   require 'calabash/http'
@@ -23,7 +23,7 @@ module Calabash
 
 
   include Utility
-  include Calabash::Operations
+  include Calabash::AppLifeCycle
   include Calabash::Wait
   include Calabash::Screenshot
   include Calabash::Gestures

--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -120,6 +120,12 @@ module Calabash
     _clear_app_data(path_or_application)
   end
 
+  # @todo Needs a better home.
+  # @todo Needs docs!
+  def query(query, *args)
+    Calabash::Device.default.map_route(query, :query, *args)
+  end
+
   def self.new_embed_method!(method)
     EmbeddingContext.new_embed_method(method)
   end

--- a/lib/calabash/android.rb
+++ b/lib/calabash/android.rb
@@ -27,7 +27,6 @@ module Calabash
 
     require 'calabash/android/application'
     require 'calabash/android/build'
-    require 'calabash/android/operations'
     require 'calabash/android/device'
     require 'calabash/android/screenshot'
     require 'calabash/android/server'

--- a/lib/calabash/android/operations.rb
+++ b/lib/calabash/android/operations.rb
@@ -1,6 +1,0 @@
-module Calabash
-  module Android
-    module Operations
-    end
-  end
-end

--- a/lib/calabash/app_life_cycle.rb
+++ b/lib/calabash/app_life_cycle.rb
@@ -1,5 +1,5 @@
 module Calabash
-  module Operations
+  module AppLifeCycle
 
     # @todo Needs docs!
     def query(query, *args)

--- a/lib/calabash/app_life_cycle.rb
+++ b/lib/calabash/app_life_cycle.rb
@@ -1,11 +1,6 @@
 module Calabash
   module AppLifeCycle
 
-    # @todo Needs docs!
-    def query(query, *args)
-      Calabash::Device.default.map_route(query, :query, *args)
-    end
-
     # @!visibility private
     def _start_app(application, options={})
       test_options = options.dup

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -27,10 +27,8 @@ module Calabash
     require 'calabash/ios/environment'
     require 'calabash/ios/device/physical_device_mixin'
     require 'calabash/ios/device/device'
-    require 'calabash/ios/operations'
     require 'calabash/ios/server'
     require 'calabash/ios/application'
 
-    include Calabash::IOS::Operations
   end
 end

--- a/lib/calabash/ios/operations.rb
+++ b/lib/calabash/ios/operations.rb
@@ -1,7 +1,0 @@
-module Calabash
-  module IOS
-    module Operations
-
-    end
-  end
-end

--- a/spec/lib/app_life_cycle_spec.rb
+++ b/spec/lib/app_life_cycle_spec.rb
@@ -1,6 +1,6 @@
-describe Calabash::Operations do
-  let(:operations_class) {Class.new {include Calabash::Operations}}
-  let(:operations) {operations_class.new}
+describe Calabash::AppLifeCycle do
+  let(:life_cycle_class) {Class.new {include Calabash::AppLifeCycle}}
+  let(:life_cycle) {life_cycle_class.new}
   let(:dummy_device_class) {Class.new(Calabash::Device) {def initialize; end}}
   let(:dummy_device) {dummy_device_class.new}
 
@@ -15,7 +15,7 @@ describe Calabash::Operations do
       expect(options).to receive(:dup).and_return(dup_options)
       expect(Calabash::Device.default).to receive(:start_app).with(app, dup_options)
 
-      operations._start_app(app, options)
+      life_cycle._start_app(app, options)
     end
   end
 
@@ -24,7 +24,7 @@ describe Calabash::Operations do
       allow(Calabash::Device).to receive(:default).and_return(dummy_device)
       expect(Calabash::Device.default).to receive(:stop_app)
 
-      operations._stop_app
+      life_cycle._stop_app
     end
   end
 end


### PR DESCRIPTION
### Motivation

* Refactor: rename operations => lifecycle. #105

It is clear that the `query` method does not belong in `app_life_cycle` so I moved it to lib/calabash.rb.  I am pretty sure it does belong there either.

I am also not sure that all the life cycle methods should be in lib/calabash.rb either.