### PR TITLE
Rename operations to api

### DIFF
--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -5,7 +5,7 @@ module Calabash
   require 'calabash/color'
   require 'calabash/utility'
   require 'calabash/application'
-  require 'calabash/operations'
+  require 'calabash/api'
   require 'calabash/managed'
   require 'calabash/device'
   require 'calabash/http'
@@ -23,7 +23,7 @@ module Calabash
 
 
   include Utility
-  include Calabash::Operations
+  include Calabash::API
   include Calabash::Wait
   include Calabash::Screenshot
   include Calabash::Gestures

--- a/lib/calabash/android.rb
+++ b/lib/calabash/android.rb
@@ -27,7 +27,7 @@ module Calabash
 
     require 'calabash/android/application'
     require 'calabash/android/build'
-    require 'calabash/android/operations'
+    require 'calabash/android/api'
     require 'calabash/android/device'
     require 'calabash/android/screenshot'
     require 'calabash/android/server'

--- a/lib/calabash/android/api.rb
+++ b/lib/calabash/android/api.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    module Operations
+    module API
     end
   end
 end

--- a/lib/calabash/api.rb
+++ b/lib/calabash/api.rb
@@ -1,5 +1,5 @@
 module Calabash
-  module Operations
+  module API
 
     # @todo Needs docs!
     def query(query, *args)

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -31,7 +31,7 @@ module Calabash
 
     require 'calabash/ios/device/device'
 
-    require 'calabash/ios/operations'
+    require 'calabash/ios/api'
     require 'calabash/ios/server'
     require 'calabash/ios/application'
   end

--- a/lib/calabash/ios/api.rb
+++ b/lib/calabash/ios/api.rb
@@ -1,6 +1,6 @@
 module Calabash
   module IOS
-    module Operations
+    module API
 
     end
   end

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -1,5 +1,5 @@
-describe Calabash::Operations do
-  let(:operations_class) {Class.new {include Calabash::Operations}}
+describe Calabash::API do
+  let(:operations_class) {Class.new {include Calabash::API}}
   let(:operations) {operations_class.new}
   let(:dummy_device_class) {Class.new(Calabash::Device) {def initialize; end}}
   let(:dummy_device) {dummy_device_class.new}


### PR DESCRIPTION
### Motivation

Operations is an ambiguous word.  This file should be used to expose the Calabash API to Cucumber, rspec, or any other test-runner.