### PR TITLE
iOS replace 'cucumber' interface with 'api' interface

### DIFF
--- a/cucumber/ios/features/support/env.rb
+++ b/cucumber/ios/features/support/env.rb
@@ -1,9 +1,9 @@
 require 'calabash'
 require 'calabash/ios'
-World(Calabash::IOS)
+require 'calabash/ios/api'
 
-require 'calabash/ios/cucumber'
-World(Calabash::IOS::Cucumber)
+World(Calabash)
+World(Calabash::IOS::API)
 
 Calabash::Application.default = Calabash::IOS::Application.default_from_environment
 

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -14,25 +14,10 @@ module Calabash
       Calabash.send(:included, base)
     end
 
-    require 'calabash/ios/device/runtime_attributes'
-    require 'calabash/ios/device/routes/error'
-    require 'calabash/ios/device/routes/handle_route_mixin'
-    require 'calabash/ios/device/routes/map_route_mixin'
-    require 'calabash/ios/device/routes/uia_route_mixin'
-
-    require 'calabash/ios/device/gestures_mixin'
-
     require 'calabash/ios/environment'
-    require 'calabash/ios/device/physical_device_mixin'
-    require 'calabash/ios/device/status_bar_mixin'
-    require 'calabash/ios/device/keyboard_mixin'
-    require 'calabash/ios/device/uia_keyboard_mixin'
-    require 'calabash/ios/device/text_mixin'
-
-    require 'calabash/ios/device/device'
-
     require 'calabash/ios/api'
     require 'calabash/ios/server'
     require 'calabash/ios/application'
+    require 'calabash/ios/device'
   end
 end

--- a/lib/calabash/ios/api.rb
+++ b/lib/calabash/ios/api.rb
@@ -1,7 +1,8 @@
 module Calabash
   module IOS
     module API
-
+      require 'calabash/ios/api/keyboard'
+      require 'calabash/ios/api/status_bar'
     end
   end
 end

--- a/lib/calabash/ios/api/keyboard.rb
+++ b/lib/calabash/ios/api/keyboard.rb
@@ -1,6 +1,6 @@
 module Calabash
   module IOS
-    module Cucumber
+    module API
 
       # Returns true if a docked keyboard is visible.
       #

--- a/lib/calabash/ios/api/status_bar.rb
+++ b/lib/calabash/ios/api/status_bar.rb
@@ -1,6 +1,6 @@
 module Calabash
   module IOS
-    module Cucumber
+    module API
       # Returns the home button position relative to the status bar.
       #
       # @note This method works even if a status bar is not visible.

--- a/lib/calabash/ios/cucumber.rb
+++ b/lib/calabash/ios/cucumber.rb
@@ -1,8 +1,0 @@
-module Calabash
-  module IOS
-    module Cucumber
-      require 'calabash/ios/cucumber/status_bar'
-      require 'calabash/ios/cucumber/keyboard'
-    end
-  end
-end

--- a/lib/calabash/ios/device.rb
+++ b/lib/calabash/ios/device.rb
@@ -1,0 +1,18 @@
+module Calabash
+  module IOS
+
+    require 'calabash/ios/device/runtime_attributes'
+    require 'calabash/ios/device/routes/error'
+    require 'calabash/ios/device/routes/handle_route_mixin'
+    require 'calabash/ios/device/routes/map_route_mixin'
+    require 'calabash/ios/device/routes/uia_route_mixin'
+    require 'calabash/ios/device/gestures_mixin'
+    require 'calabash/ios/device/physical_device_mixin'
+    require 'calabash/ios/device/status_bar_mixin'
+    require 'calabash/ios/device/keyboard_mixin'
+    require 'calabash/ios/device/uia_keyboard_mixin'
+    require 'calabash/ios/device/text_mixin'
+    require 'calabash/ios/device/device'
+
+  end
+end

--- a/spec/lib/ios/api/keyboard_spec.rb
+++ b/spec/lib/ios/api/keyboard_spec.rb
@@ -1,4 +1,4 @@
-describe Calabash::IOS::Cucumber do
+describe Calabash::IOS::API do
 
   let(:device) do
     Class.new do
@@ -12,8 +12,8 @@ describe Calabash::IOS::Cucumber do
 
   let(:world) do
     Class.new do
-      require 'calabash/ios/cucumber'
-      include Calabash::IOS::Cucumber
+      require 'calabash/ios/api'
+      include Calabash::IOS::API
       def to_s
         '#<Cucumber World>'
       end

--- a/spec/lib/ios/api/status_bar_spec.rb
+++ b/spec/lib/ios/api/status_bar_spec.rb
@@ -1,4 +1,4 @@
-describe Calabash::IOS::Cucumber do
+describe Calabash::IOS::API do
 
   let(:device) do
     Class.new do
@@ -8,8 +8,8 @@ describe Calabash::IOS::Cucumber do
 
   let(:world) do
     Class.new do
-      require 'calabash/ios/cucumber'
-      include Calabash::IOS::Cucumber
+      require 'calabash/ios/api'
+      include Calabash::IOS::API
       def to_s
         '#<Cucumber World>'
       end


### PR DESCRIPTION
### Motivation

Now that 'Operations' is 'API' it is clear that we don't need this IOS::Cucumber module.

