### PR TITLE
Allow support/env.rb require and World platform

### DIFF
--- a/cucumber/android/features/support/env.rb
+++ b/cucumber/android/features/support/env.rb
@@ -1,7 +1,5 @@
-require 'calabash/api'
 require 'calabash/android'
 
-World(Calabash::API)
 World(Calabash::Android)
 
 identifier = Calabash::Android::Device.default_serial

--- a/cucumber/ios/features/support/env.rb
+++ b/cucumber/ios/features/support/env.rb
@@ -1,10 +1,6 @@
-require 'calabash/api'
 require 'calabash/ios'
-require 'calabash/ios/api'
 
-World(Calabash)
-World(Calabash::API)
-World(Calabash::IOS::API)
+World(Calabash::IOS)
 
 Calabash::Application.default = Calabash::IOS::Application.default_from_environment
 

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -19,5 +19,7 @@ module Calabash
     require 'calabash/ios/server'
     require 'calabash/ios/application'
     require 'calabash/ios/device'
+
+    include Calabash::IOS::API
   end
 end

--- a/lib/calabash/ios/api.rb
+++ b/lib/calabash/ios/api.rb
@@ -1,11 +1,14 @@
 module Calabash
   module IOS
     module API
+      require 'calabash/api'
       require 'calabash/gestures'
       require 'calabash/wait'
       require 'calabash/ios/api/keyboard'
       require 'calabash/ios/api/status_bar'
       require 'calabash/ios/api/text'
+
+      include Calabash::API
     end
   end
 end


### PR DESCRIPTION
### Motivation

I wanted this pattern:

```
# support/env.rb
require 'calabash/<platform>/api'
World(Calabash::<platform>/API)
```

but it turned out to be impractical and (probably) the wrong pattern.

This is what I have settle on for now:

```
# Android: support/env.rb
require 'calabash/android'
World(Calabash::Android)

# iOS: support/env.rb
require 'calabash/ios'
World(Calabash::IOS)
```
