### PR TITLE
iOS: move backdoor implementation to route mixin

### DIFF
--- a/cucumber/ios/features/backdoor.feature
+++ b/cucumber/ios/features/backdoor.feature
@@ -1,0 +1,100 @@
+@backdoor
+Feature:  Backdoors
+  In order make UI testing faster and easier
+  As a tester
+  I want a way to get my app into a good shape for testing
+  and to get some state from my app at runtime
+
+  # We've been advocating only one kind of signature for backdoor methods.
+  #
+  # - (NSString *) backdoorWithString:(NSString *) argument
+  #
+  # The server can actually handle other kinds method signatures.
+  #
+  # The rules for valid backdoor methods are:
+  #
+  #  1. It must be implemented in the UIApplicationDelegate.
+  #  2. It must take exactly one argument.
+  #  3. The argument must be NSString, NSArray, NSDictionary, or NSNumber.
+  #  4. It must return an NSString, NSArray, NSDictionary, or NSNumber.
+  #
+  # Valid.
+  #
+  # - (NSNumber *) numberFromString:(NSString *) argument
+  # - (NSDictionary *) dictionaryFromString:(NSString *) argument
+  # - (NSArray *) arrayFromString:(NSString *) argument
+  #
+  # - (NSString *) stringWithDictionary:(NSDictionary *) argument
+  # - (NSString *) stringWithArray:(NSArray *) argument
+  # - (NSString *) stringWithNumber:(NSNumber *) argument
+  #
+  # Invalid: App will crash.
+  #
+  # - (void) backdoorWithVoidReturnType:(NSString *) argument
+  # - (BOOL) doesStateMatchStringArgument:(NSString *) argument
+  # - (NSUInteger) countOfCoreDataEntitiesWithName:(NSString *) argument
+  #
+  # Invalid: Will return unpredictable results or cause a crash.
+  #
+  # - (NSString *) stringWithBOOL:(BOOL) argument
+  # - (NSString *) stringWithNSUInteger:(NSUInteger) argument
+
+  Background: The app has launched
+    Given I see the first tab
+
+  Scenario: Backdoor selector is unknown
+    And I call backdoor with an unknown selector
+    Then I should see a helpful error message
+
+  @expect_crash
+  Scenario: Calling backdoor with void return type causes a crash
+    And I call backdoor on a method whose return type is void
+    Then the app should crash
+
+  @expect_crash
+  Scenario: Calling backdoor with primitive return type causes a crash
+    And I call backdoor on a method that returns a primitive
+    Then the app should crash
+
+  @invalid_signature
+  Scenario: Backdoors with primitive argument (NSUInteger) are unpredictable
+    And I call backdoor on a method that takes an NSUInteger argument
+    Then I won't get back that integer as a string
+
+  @invalid_signature
+  Scenario: Backdoors with primitive argument (BOOL) are unpredictable
+    And I call backdoor on a method that takes a boolean argument
+    Then I won't get back that boolean as a string
+
+  @invalid_signature
+  Scenario: Backdoor with missing : in signature
+    And I call a valid backdoor but forget to include the trailing colon
+    Then backdoor will raise an argument error
+
+  Scenario: Backdoor that returns NSNumber
+    And I call backdoor on a method that returns an NSNumber
+    Then I get back the length of the argument I passed
+
+  Scenario: Backdoor that returns an NSDictionary
+    And I call backdoor on a method with NSDictionary return type
+    Then I get back the argument I passed as a dictionary
+
+  Scenario: Backdoor that returns an NSArray
+    And I call backdoor on a method with NSArray return type
+    Then I get back the argument I passed as an array
+
+  Scenario: Backdoor that takes an NSString argument
+    And I call backdoor on a method that takes an NSString as an argument
+    Then I should get back that string
+
+  Scenario: Backdoor that takes an NSDictionary argument
+    And I call backdoor on a method that takes an NSDictionary as an argument
+    Then I get back the length of that dictionary as a string
+
+  Scenario: Backdoor that takes an NSArray argument
+    And I call backdoor on a method that takes an NSArray as an argument
+    Then I get back the length of the array as a number
+
+  Scenario: Backdoor that take a NSNumber argument
+    And I call backdoor on a method that takes a number argument
+    Then I get back that number as a string

--- a/cucumber/ios/features/step_definitions/backdoor_steps.rb
+++ b/cucumber/ios/features/step_definitions/backdoor_steps.rb
@@ -1,0 +1,146 @@
+module CalSmoke
+  module Backdoor
+
+    def log_app_crashed
+      puts "\033[36m   App crashed.\033[0m"
+    end
+  end
+end
+
+World(CalSmoke::Backdoor)
+
+And(/^I call backdoor with an unknown selector$/) do
+  begin
+    backdoor('unknownSelector:', '')
+  rescue RuntimeError => e
+    puts e
+    @backdoor_raised_an_error = true
+  end
+end
+
+Then(/^I should see a helpful error message$/) do
+  expect(@backdoor_raised_an_error).to be == true
+end
+
+Then(/^the app should crash$/) do
+  expect(@app_crashed).to be == true
+end
+
+And(/^I call backdoor on a method whose return type is void$/) do
+  begin
+    backdoor('backdoorWithVoidReturn:', 'argument');
+  rescue Calabash::IOS::Routes::RouteError => _
+    log_app_crashed
+    @app_crashed = true
+  end
+end
+
+And(/^I call backdoor on a method with no argument$/) do
+  backdoor('backdoorWithArgument', nil)
+end
+
+And(/^I call backdoor on a method that returns an NSNumber$/) do
+  @backdoor_argument = 'argument'
+  @backdoor_result = backdoor('numberFromString:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method that returns a primitive$/) do
+  begin
+    backdoor('doesStateMatchStringArgument:', 'argument')
+  rescue Calabash::IOS::Routes::RouteError
+    log_app_crashed
+    @app_crashed = true
+  end
+end
+
+And(/^I call backdoor on a method that takes an NSString as an argument$/) do
+  @backdoor_argument = 'argument'
+  @backdoor_result = backdoor('stringByReturningString:', @backdoor_argument)
+end
+
+And(/^I call a valid backdoor but forget to include the trailing colon$/) do
+  begin
+    backdoor('stringByReturningString', 'argument')
+  rescue ArgumentError => e
+    @backdoor_raised_error = e
+  end
+end
+
+Then(/backdoor will raise an argument error$/) do
+  expect(@backdoor_raised_error).to be_a_kind_of(ArgumentError)
+end
+
+And(/^I call backdoor on a method that takes an NSDictionary as an argument$/) do
+  @backdoor_argument = {'a' => 1, 'b' => 2, 'c' => 3}
+  @backdoor_result = backdoor('stringByEncodingLengthOfDictionary:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method with NSArray return type$/) do
+  @backdoor_argument = 'argument'
+  @backdoor_result = backdoor('arrayByInsertingString:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method with NSDictionary return type$/) do
+  @backdoor_argument = 'argument'
+  @backdoor_result = backdoor('dictionaryByInsertingString:', 'argument')
+end
+
+And(/^I call backdoor on a method that takes a boolean argument$/) do
+  @backdoor_argument = true
+  @backdoor_result = backdoor('stringByEncodingBOOL:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method that takes an NSArray as an argument$/) do
+  @backdoor_argument = [1, 2, 3]
+  @backdoor_result = backdoor('numberWithCountOfArray:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method that takes an NSUInteger argument$/) do
+  @backdoor_argument = 17
+  @backdoor_result = backdoor('stringByEncodingNSUInteger:', @backdoor_argument)
+end
+
+And(/^I call backdoor on a method that takes a number argument$/) do
+  @backdoor_argument = 10
+  @backdoor_result = backdoor('stringByEncodingNumber:', @backdoor_argument)
+end
+
+And(/^I should get back that string$/) do
+  expect(@backdoor_result).to be == @backdoor_argument
+end
+
+Then(/^I should get back the argument I passed$/) do
+  expect(@backdoor_result).to be == @backdoor_argument
+end
+
+Then(/^I get back the length of the argument I passed$/) do
+  expect(@backdoor_result).to be == @backdoor_argument.length
+end
+
+Then(/^I get back the argument I passed as a dictionary$/) do
+  expect(@backdoor_result).to be == {@backdoor_argument => @backdoor_argument}
+end
+
+Then(/^I get back the argument I passed as an array$/) do
+  expect(@backdoor_result).to be == [@backdoor_argument]
+end
+
+Then(/^I get back the length of that dictionary as a string$/) do
+  expect(@backdoor_result).to be == '3'
+end
+
+Then(/^I won't get back that boolean as a string$/) do
+  expect(@backdoor_result).not_to be == "#{@backdoor_argument}"
+end
+
+Then(/^I get back the length of the array as a number$/) do
+  expect(@backdoor_result).to be == @backdoor_argument.length
+end
+
+Then(/^I get back that number as a string$/) do
+  expect(@backdoor_result).to be == "#{@backdoor_argument}"
+end
+
+Then(/^I won't get back that integer as a string$/) do
+  expect(@backdoor_result).not_to be == "#{@backdoor_argument}"
+end

--- a/lib/calabash/interactions.rb
+++ b/lib/calabash/interactions.rb
@@ -28,7 +28,8 @@ module Calabash
     #  NSDictionary (Ruby Hash).
     #
     #
-    # For iOS
+    # ### For iOS
+    #
     # You must create a method on you app delegate of the form:
     #
     #     - (NSString *) calabashBackdoor:(NSString *)aIgnorable;
@@ -37,7 +38,8 @@ module Calabash
     #
     #     - (NSString *) calabashBackdoor:(NSDictionary *)params;
     #
-    # For Android
+    # ### For Android
+    #
     # You must create a public method in your current Activity or Application.
     #
     #     public <return type> calabashBackdoor(String param1, int param2)
@@ -54,7 +56,9 @@ module Calabash
     #   # Android
     #   backdoor('calabashBackdoor', 'first argument', 2)
     #
-    # @param [String] The selector/method name.
+    # @param [String] name The selector/method name.
+    # @param [Object] *arguments A comma separated list of arguments to be
+    #  passed to the backdoor selector/method.
     # @return [Object] the result of performing the selector/method with the
     #  arguments (serialized)
     def backdoor(name, *arguments)

--- a/lib/calabash/ios/device.rb
+++ b/lib/calabash/ios/device.rb
@@ -7,6 +7,7 @@ module Calabash
     require 'calabash/ios/device/routes/map_route_mixin'
     require 'calabash/ios/device/routes/uia_route_mixin'
     require 'calabash/ios/device/routes/condition_route_mixin'
+    require 'calabash/ios/device/routes/backdoor_route_mixin'
     require 'calabash/ios/device/gestures_mixin'
     require 'calabash/ios/device/physical_device_mixin'
     require 'calabash/ios/device/status_bar_mixin'

--- a/lib/calabash/ios/device/device.rb
+++ b/lib/calabash/ios/device/device.rb
@@ -9,6 +9,7 @@ module Calabash
       include Calabash::IOS::Routes::MapRouteMixin
       include Calabash::IOS::Routes::UIARouteMixin
       include Calabash::IOS::Routes::ConditionRouteMixin
+      include Calabash::IOS::Routes::BackdoorRouteMixin
       include Calabash::IOS::StatusBarMixin
       include Calabash::IOS::KeyboardMixin
       include Calabash::IOS::UIAKeyboardMixin
@@ -297,31 +298,6 @@ module Calabash
         # Can also be obtained by asking the server after the app is launched
         # on the device which would be cheaper.
         run_loop_device.simulator?
-      end
-
-      # @!visibility private
-      def backdoor(method, *arguments)
-        if arguments.length > 1
-          raise 'Backdoor in Calabash iOS does not support more than one argument'
-        end
-
-        parameters =
-            {
-                :selector => method,
-                :arg => arguments.first
-            }.to_json
-
-        request = request_factory('backdoor', parameters)
-
-        body = http_client.post(request).body
-
-        result = JSON.parse(body)
-
-        if result['outcome'] != 'SUCCESS'
-          raise "backdoor #{parameters} failed because: #{result['reason']}\n#{result['details']}"
-        end
-
-        result['result']
       end
 
       # @see Calabash::Location#set_location

--- a/lib/calabash/ios/device/routes/backdoor_route_mixin.rb
+++ b/lib/calabash/ios/device/routes/backdoor_route_mixin.rb
@@ -1,0 +1,86 @@
+module Calabash
+  module IOS
+
+    # @!visibility private
+    class BackdoorError < StandardError;  end
+
+    # @!visibility private
+    module Routes
+      # @!visibility private
+      module BackdoorRouteMixin
+
+
+        # @!visibility private
+        def backdoor(selector_name, *arguments)
+          request = make_backdoor_request(selector_name, arguments)
+          response = route_post_request(request)
+          handle_backdoor_response(selector_name, arguments, response)
+        end
+
+        private
+
+        def make_backdoor_parameters(selector_name, arguments)
+          if arguments.length > 1
+            message = 'Calabash iOS does not support backdoor selectors with ' \
+                      "more than one argument. Received #{arguments}"
+            raise ArgumentError, message
+          end
+
+          if arguments.length < 1
+            message = "Calabash iOS does not support backdoor selectors with no arguments."
+            raise ArgumentError, message
+          end
+
+           unless selector_name.end_with?(':')
+             messages =
+               [
+                 "Selector '#{selector_name}' is missing a trailing ':'",
+                 'Valid backdoor selectors must take one argument.',
+                 '',
+                 'http://developer.xamarin.com/guides/testcloud/calabash/working-with/backdoors/#backdoor_in_iOS',
+                 ''
+               ]
+               raise ArgumentError, messages.join("\n")
+           end
+
+          {
+             :selector => selector_name,
+             :arg => arguments.first
+          }
+        end
+
+        def make_backdoor_request(selector_name, arguments)
+           parameters = make_backdoor_parameters(selector_name, arguments)
+          begin
+            Calabash::HTTP::Request.request('backdoor', parameters)
+          rescue => e
+            raise RouteError, e
+          end
+        end
+
+        def handle_backdoor_response(selector_name, arguments, response)
+          body = response.body
+          begin
+            hash = JSON.parse(body)
+          rescue TypeError, JSON::ParserError => e
+            raise RouteError, "Could not parse response '#{body}: #{e}'"
+          end
+
+          outcome = hash['outcome']
+
+          case outcome
+            when 'FAILURE'
+              message = "Calling backdoor '#{selector_name}' with arguments '#{arguments}'" \
+                "failed because:\n\n#{hash['reason']}\n#{hash['details']}"
+              raise Calabash::IOS::BackdoorError, message
+            when 'SUCCESS'
+              return hash['result']
+            else
+              raise RouteError, "Server responded with an invalid outcome: '#{hash['outcome']}'"
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lib/ios/device/routes/backdoor_route_mixin_spec.rb
+++ b/spec/lib/ios/device/routes/backdoor_route_mixin_spec.rb
@@ -1,0 +1,108 @@
+describe Calabash::IOS::Routes::BackdoorRouteMixin do
+  let(:route_error) { Calabash::IOS::Routes::RouteError }
+
+  let(:device) do
+    Class.new do
+      include Calabash::IOS::Routes::BackdoorRouteMixin
+    end.new
+  end
+
+  let(:response) do
+    Class.new do
+      def body; ; ; end
+    end.new
+  end
+
+  describe 'make_backdoor_parameters' do
+    describe 'raises an error when' do
+      it 'when a list of length > 1 is passed' do
+        arguments = [1, 2]
+
+        expect {
+          device.send(:make_backdoor_parameters, 'selector:', arguments)
+        }.to raise_error ArgumentError
+      end
+
+      it 'when a list of length < 1 is passed' do
+        arguments = []
+
+        expect {
+          device.send(:make_backdoor_parameters, 'selector:', arguments)
+        }.to raise_error ArgumentError
+      end
+
+      it 'when selector does not end with :' do
+        arguments = [1, 2]
+        selector = 'selector'
+
+        expect {
+          device.send(:make_backdoor_parameters, selector, arguments)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    it 'assigns key/values correctly' do
+      expected = {
+        :selector => 'selector:',
+        :arg => 'arg!'
+      }
+      actual = device.send(:make_backdoor_parameters, 'selector:', ['arg!'])
+      expect(actual).to be == expected
+    end
+  end
+
+  describe '#handle_backdoor_response' do
+    describe 'raises an error when' do
+       describe 'cannot parse the response body' do
+         it 'TypeError' do
+           expect(JSON).to receive(:parse).and_raise TypeError
+
+           expect {
+            device.send(:handle_backdoor_response, 'selector:', [], response)
+           }.to raise_error route_error
+         end
+
+         it 'ParseError' do
+           expect(JSON).to receive(:parse).and_raise JSON::ParserError
+
+           expect {
+            device.send(:handle_backdoor_response, 'selector:', [], response)
+           }.to raise_error route_error
+         end
+       end
+
+       it 'receives an unknown outcome' do
+         expect(JSON).to receive(:parse).and_return({'outcome' => 'unknown'})
+
+         expect {
+           device.send(:handle_backdoor_response, 'selector:', [], response)
+         }.to raise_error route_error
+
+         expect(JSON).to receive(:parse).and_return({'outcome' => nil})
+
+         expect {
+           device.send(:handle_backdoor_response, 'selector:', [], response)
+         }.to raise_error route_error
+       end
+    end
+
+    it 'returns true for SUCCESS outcome' do
+      expect(JSON).to receive(:parse).and_return({'outcome' => 'SUCCESS',
+                                                  'result' => [1]})
+      expected = [1]
+      actual = device.send(:handle_backdoor_response, 'selector:', [], response)
+      expect(actual).to be == expected
+    end
+
+    it 'returns false for FAILURE outcome' do
+      expect(JSON).to receive(:parse).and_return({'outcome' => 'FAILURE',
+                                                  'details' => 'Details!',
+                                                  'reason' => 'Reason!'})
+
+      expect {
+        device.send(:handle_backdoor_response, 'selector:', [], response)
+      }.to raise_error Calabash::IOS::BackdoorError
+    end
+  end
+end
+


### PR DESCRIPTION
### Movitation

There were several edge cases not handled by the implementation in iOS::Device.

Add a bunch of Cucumbers that describe the API.