### PR TITLE
iOS implement console_attach

### DIFF
--- a/lib/calabash/ios/console_helpers.rb
+++ b/lib/calabash/ios/console_helpers.rb
@@ -17,5 +17,28 @@ module Calabash
         output("\n", indentation)
       end
     end
+
+    def console_attach(uia_strategy=nil)
+      Calabash::Application.default = Calabash::IOS::Application.default_from_environment
+
+      identifier = Calabash::IOS::Device.default_identifier_for_application(Calabash::Application.default)
+      server = Calabash::IOS::Server.default
+
+      device =  Calabash::IOS::Device.new(identifier, server)
+      Calabash::Device.default = device
+
+      begin
+        Calabash::Device.default.ensure_test_server_ready({:timeout => 4})
+      rescue RuntimeError => e
+        if e.to_s == 'Calabash server did not respond'
+          raise RuntimeError, 'You can only attach to a running Calabash iOS App'
+        else
+          raise e
+        end
+      end
+
+      run_loop_device = device.send(:run_loop_device)
+      Calabash::Device.default.send(:attach_to_run_loop, run_loop_device, uia_strategy)
+    end
   end
 end

--- a/spec/integration/ios/console_helper_spec.rb
+++ b/spec/integration/ios/console_helper_spec.rb
@@ -1,0 +1,79 @@
+describe Calabash::ConsoleHelpers do
+
+  # Use the console to attach to a currently running iOS app that
+  # was launched with instruments.
+  #
+  # :host is always a problem, so expect flickering specs for :host.
+  #
+  # Don't run the console in the context of bundle exec.  Instead, run rspec
+  # in the context of bundle exec: $ be rspec spec/integration/ios
+  def calabash_console_with_strategy(application, strategy=nil)
+    if strategy.nil?
+      attach_cmd = 'console_attach'
+    else
+      attach_cmd = "console_attach(:#{strategy})"
+    end
+
+    Open3.popen3('calabash', *['console', application]) do |stdin, stdout, stderr, _|
+      stdin.puts "details = #{attach_cmd}"
+      stdin.puts "tap 'textField'"
+      stdin.close
+      yield stdout, stderr
+    end
+  end
+
+  describe 'can connect to launched apps' do
+
+    before(:each) { FileUtils.rm_rf(RunLoop::HostCache.default_directory) }
+
+
+    let(:sim_name) { RunLoop::Core.default_simulator }
+
+    let(:run_loop_device) do
+      RunLoop::SimControl.new.simulators.detect do |sim|
+        sim.instruments_identifier == sim_name
+      end
+    end
+
+    let(:app_bundle_path) { IOSResources.instance.app_bundle_path }
+
+    let(:bridge) { RunLoop::Simctl::Bridge.new(run_loop_device, abp) }
+
+    let(:device) do
+      uri = URI.parse('http://localhost:37265')
+      server = Calabash::IOS::Server.new(uri)
+      Calabash::IOS::Device.new(sim_name, server)
+    end
+
+    let(:app) { Calabash::IOS::Application.new(app_bundle_path) }
+
+    it ':preferences' do
+      device.start_app(app, {:uia_strategy => :preferences})
+
+      calabash_console_with_strategy(app_bundle_path, :preferences) do |stdout, stderr|
+        expect(stdout.read.strip[/Error/,0]).to be == nil
+        expect(stderr.read.strip).to be == ''
+      end
+    end
+
+    it ':host' do
+      device.start_app(app, {:uia_strategy => :host})
+
+      calabash_console_with_strategy(app_bundle_path, :host) do |stdout, stderr|
+        puts "stdout: #{stdout.read}"
+        puts "stderr: #{stderr.read}"
+        expect(stdout.read.strip[/Error/,0]).to be == nil
+        expect(stderr.read.strip).to be == ''
+      end
+    end
+
+    it ':shared_element' do
+      device.start_app(app, {:uia_strategy => :shared_element})
+
+      calabash_console_with_strategy(app_bundle_path, :shared_element) do |stdout, stderr|
+        expect(stdout.read.strip[/Error/,0]).to be == nil
+        expect(stderr.read.strip).to be == ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

I encountered some problems with gestures and in order to debug them, I need `console_attach` in the console.

### Tests

```
$ be rspec spec/integration/ios/console_helpers.rb
```