### PR TITLE
A: A lot of keystore changes

### DIFF
--- a/bin/calabash
+++ b/bin/calabash
@@ -12,6 +12,7 @@ module Calabash
       include Calabash::CLI::Generate
       include Calabash::CLI::Resign
       include Calabash::CLI::Run
+      include Calabash::CLI::SetupKeystore
 
       def initialize(arguments)
         @arguments = arguments.dup
@@ -71,13 +72,15 @@ module Calabash
             parse_generate_arguments!
           when 'run'
             parse_run_arguments!
+          when 'setup-keystore'
+            parse_setup_keystore_arguments!
           when 'help'
             argument = @arguments.shift
 
             if argument.nil?
               print_usage
             else
-              print_usage_for(argument.to_sym)
+              print_usage_for(argument)
             end
           when nil
             print_usage

--- a/lib/calabash/android/build/resigner.rb
+++ b/lib/calabash/android/build/resigner.rb
@@ -45,7 +45,7 @@ module Calabash
           java_keystore = JavaKeystore.get_keystores.first
 
           if java_keystore.nil?
-            raise 'No keystores found. You can specify the keystore location and credentials using calabash setup'
+            raise 'No keystores found. You can specify the keystore location and credentials using calabash setup-keystore'
           end
 
           java_keystore.sign_apk(app_path, dest_path)

--- a/lib/calabash/cli.rb
+++ b/lib/calabash/cli.rb
@@ -7,5 +7,6 @@ module Calabash
     require 'calabash/cli/helpers'
     require 'calabash/cli/resign'
     require 'calabash/cli/run'
+    require 'calabash/cli/setup_keystore'
   end
 end

--- a/lib/calabash/cli/helpers.rb
+++ b/lib/calabash/cli/helpers.rb
@@ -9,20 +9,22 @@ module Calabash
           run: 'run [application] [cucumber options]',
           console: 'console [application]',
           version: 'version',
-          setup: 'setup',
+          setup_keystore: 'setup-keystore',
           resign: 'resign <apk>',
           build: 'build <apk>'
       }
 
       def print_usage_for(command, output=STDOUT)
-        if HELP[command].nil?
+        key = HELP.key('setup-keystore')
+
+        if key.nil?
           output.write <<EOF
 No such command '#{command}'
 EOF
         else
           output.write <<EOF
 Usage:
-  calabash [options] #{HELP[command]}
+  calabash [options] #{HELP[key]}
 EOF
         end
       end
@@ -48,7 +50,7 @@ EOF
       prints the gem version
 
     Android specific commands
-      #{HELP[:setup]}
+      #{HELP[:setup_keystore]}
         sets up a non-default keystore to use with this test project.
 
       #{HELP[:resign]}

--- a/lib/calabash/cli/setup_keystore.rb
+++ b/lib/calabash/cli/setup_keystore.rb
@@ -1,0 +1,39 @@
+require 'json'
+require 'awesome_print'
+require 'io/console'
+
+module Calabash
+  module CLI
+    # @!visibility private
+    module SetupKeystore
+      def parse_setup_keystore_arguments!
+        set_platform!(:android)
+
+        settings = {}
+
+        puts "Please enter keystore information to use a custom keystore instead of the default"
+
+        settings[:keystore_location] = File.expand_path(prompt('Please enter a path to the keystore'))
+        settings[:keystore_store_password] = prompt('Please enter the password for the keystore (storepass)', true)
+        settings[:keystore_alias] = prompt('Please enter the alias. Leave blank for auto-detection.')
+        settings[:keystore_key_password] = prompt('Please enter the password for the key (keypass). Leave blank if it is the same as the store password.', true)
+
+        File.open(Android::Build::JavaKeystore::CALABASH_KEYSTORE_SETTINGS_FILENAME, 'w') do |file|
+          file.puts(JSON.pretty_generate(settings))
+        end
+
+        puts "Saved your settings to '#{Android::Build::JavaKeystore::CALABASH_KEYSTORE_SETTINGS_FILENAME}'. You can edit the settings manually or run this setup script again"
+      end
+
+      def prompt(message, secure = false)
+        puts message
+
+        if secure
+          STDIN.noecho(&:gets).chomp
+        else
+          STDIN.gets.chomp
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - Use the new signing methods from 1.0, which allows DSA certs.
 - Add setup-keystore CLI command
 - Better error messages regarding keystores in general