### PR TITLE
Rspec:  fix false-positive warning when testing raise_error

### DIFF
--- a/lib/calabash/ios/device/device.rb
+++ b/lib/calabash/ios/device/device.rb
@@ -517,7 +517,7 @@ module Calabash
         begin
           bridge.reset_app_sandbox
           true
-        rescue e
+        rescue StandardError => e
           raise "Could not clear app data for #{application.identifier} on #{run_loop_device}: #{e}"
         end
       end
@@ -599,7 +599,7 @@ module Calabash
 
           bridge.uninstall
           bridge.install
-        rescue e
+        rescue StandardError => e
           raise "Could not install #{application} on #{run_loop_device}: #{e}"
         end
       end

--- a/spec/lib/ios/application_spec.rb
+++ b/spec/lib/ios/application_spec.rb
@@ -25,7 +25,7 @@ describe Calabash::IOS::Application do
 
       expect {
         Calabash::IOS::Application.new(path)
-      }.to raise_error
+      }.to raise_error RuntimeError
     end
 
     it 'sets its instance variables' do
@@ -75,7 +75,7 @@ describe Calabash::IOS::Application do
 
         expect {
           app.send(:extract_identifier)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
     end
 

--- a/spec/lib/ios/device/device_spec.rb
+++ b/spec/lib/ios/device/device_spec.rb
@@ -12,7 +12,13 @@ describe Calabash::IOS::Device do
   let(:dummy_http_class) {Class.new(Calabash::HTTP::RetriableClient) {def initialize; end}}
   let(:dummy_http) {dummy_http_class.new}
 
-  let(:run_loop_device) { RunLoop::Device.new('denis', '8.3', 'udid') }
+  let(:run_loop_device) do
+    Class.new(RunLoop::Device) do
+      def to_s ; '#< Mock RunLoop::Device>' ; end
+      def inspect; to_s; end
+    end.new('denis', '8.3', 'udid')
+  end
+
   let(:app) { Calabash::IOS::Application.new(IOSResources.instance.app_bundle_path) }
 
   # Mock RunLoop::Simctl::Bridge

--- a/spec/lib/ios/device/device_spec.rb
+++ b/spec/lib/ios/device/device_spec.rb
@@ -48,7 +48,7 @@ describe Calabash::IOS::Device do
         expect(Calabash::IOS::Device).to receive(:fetch_matching_simulator).and_return(nil)
         expect {
           Calabash::IOS::Device.default_simulator_identifier
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'returns the instruments identifier of the simulator' do
@@ -74,7 +74,7 @@ describe Calabash::IOS::Device do
         expect(Calabash::IOS::Device).to receive(:fetch_matching_physical_device).and_return(nil)
         expect {
           Calabash::IOS::Device.default_physical_device_identifier
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'returns the instruments identifier of the device' do
@@ -93,7 +93,7 @@ describe Calabash::IOS::Device do
           allow_any_instance_of(RunLoop::XCTools).to receive(:instruments).with(:devices).and_return([])
           expect {
             Calabash::IOS::Device.default_physical_device_identifier
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'there is more than one connected device' do
@@ -101,7 +101,7 @@ describe Calabash::IOS::Device do
           allow_any_instance_of(RunLoop::XCTools).to receive(:instruments).with(:devices).and_return([1, 2])
           expect {
             Calabash::IOS::Device.default_physical_device_identifier
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
       end
 
@@ -134,7 +134,7 @@ describe Calabash::IOS::Device do
       expect(app).to receive(:device_binary?).and_return(false)
       expect {
         Calabash::IOS::Device.default_identifier_for_application(app)
-      }.to raise_error
+      }.to raise_error RuntimeError
     end
   end
 
@@ -152,7 +152,7 @@ describe Calabash::IOS::Device do
         expect(Calabash::IOS::Device).to receive(:fetch_matching_simulator).and_return(nil)
         expect {
           Calabash::IOS::Device.send(:expect_compatible_server_endpoint, 'my id', server)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'does nothing if the identifier resolves to a simulator' do
@@ -232,7 +232,7 @@ describe Calabash::IOS::Device do
         expect(app).to receive(:device_binary?).and_return false
         expect {
           device.start_app(app)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'calls start_app_on_simulator when app is a simulator bundle' do
@@ -299,7 +299,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:test_server_responding?).and_return(true)
         expect(device.http_client).to receive(:get).and_raise(Calabash::HTTP::Error)
 
-        expect { device.stop_app }.to raise_error
+        expect { device.stop_app }.to raise_error RuntimeError
         expect(device.send(:runtime_attributes)).to be == nil
       end
     end
@@ -308,7 +308,7 @@ describe Calabash::IOS::Device do
       it 'raise an exception if the server cannot be reached' do
         expect(device.http_client).to receive(:get).and_raise(Calabash::HTTP::Error)
 
-        expect { device.screenshot('path') }.to raise_error
+        expect { device.screenshot('path') }.to raise_error RuntimeError
       end
 
       it 'writes screenshot to a file' do
@@ -331,7 +331,7 @@ describe Calabash::IOS::Device do
 
         expect {
           device.install_app(app)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       describe 'on a simulator' do
@@ -341,7 +341,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.install_app(app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls install_app_on_simulator' do
@@ -362,7 +362,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.install_app(app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls install_app_on_device' do
@@ -384,7 +384,7 @@ describe Calabash::IOS::Device do
 
         expect {
           device.ensure_app_installed(app)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       describe 'on a simulator' do
@@ -394,7 +394,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.ensure_app_installed(app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'does nothing if app is already installed' do
@@ -426,7 +426,7 @@ describe Calabash::IOS::Device do
 
             expect {
               device.ensure_app_installed(app)
-            }.to raise_error
+            }.to raise_error RuntimeError
           end
 
           it 'calls install_app_on_device' do
@@ -464,7 +464,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.send(:install_app_on_simulator, app, run_loop_device)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls bridge.uninstall and an exception is raised' do
@@ -472,7 +472,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.send(:install_app_on_simulator, app, run_loop_device, mock_bridge)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls bridge.install and an exception is raised' do
@@ -481,7 +481,7 @@ describe Calabash::IOS::Device do
 
           expect {
             device.send(:install_app_on_simulator, app, run_loop_device, mock_bridge)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
       end
     end
@@ -492,7 +492,7 @@ describe Calabash::IOS::Device do
 
         expect {
           device.send(:start_app_on_simulator, app, {})
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'starts the app' do
@@ -511,7 +511,7 @@ describe Calabash::IOS::Device do
 
         expect {
           device.send(:start_app_on_physical_device, app, {})
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'starts the app' do
@@ -549,7 +549,7 @@ describe Calabash::IOS::Device do
         expect(mock_bridge).to receive(:app_is_installed?).and_return(false)
         expect {
           device.send(:expect_app_installed_on_simulator, mock_bridge)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'returns true if app is installed' do
@@ -566,7 +566,7 @@ describe Calabash::IOS::Device do
         expect(app).to receive(:sha1).at_least(:once).and_return('fghij')
         expect {
           device.send(:expect_matching_sha1s, installed_app, app)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'returns true if the sha1s match' do
@@ -595,7 +595,7 @@ describe Calabash::IOS::Device do
     it '#clear_app_data_on_physical_device' do
       expect {
         device.clear_app_data_on_physical_device(nil, nil)
-      }.to raise_error
+      }.to raise_error Calabash::AbstractMethodError
     end
 
     describe '#clear_app_on_simulator' do
@@ -603,7 +603,7 @@ describe Calabash::IOS::Device do
         expect(mock_bridge).to receive(:reset_app_sandbox).and_raise
         expect {
           device.send(:clear_app_data_on_simulator, app, run_loop_device, mock_bridge)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'resets the app sandbox' do
@@ -619,7 +619,7 @@ describe Calabash::IOS::Device do
           expect(Calabash::IOS::Device).to receive(:fetch_matching_simulator).and_return nil
           expect {
             device.send(:clear_app_data, app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls clear_app_on_simulator when the app is installed' do
@@ -649,7 +649,7 @@ describe Calabash::IOS::Device do
           expect(Calabash::IOS::Device).to receive(:fetch_matching_physical_device).and_return nil
           expect {
             device.send(:clear_app_data, app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls clear_app_on_physical_device' do
@@ -670,7 +670,7 @@ describe Calabash::IOS::Device do
           expect(Calabash::IOS::Device).to receive(:fetch_matching_simulator).and_return nil
           expect {
             device.send(:uninstall_app, app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls uninstall_app_on_simulator when the app is installed' do
@@ -700,7 +700,7 @@ describe Calabash::IOS::Device do
           expect(Calabash::IOS::Device).to receive(:fetch_matching_physical_device).and_return nil
           expect {
             device.send(:uninstall_app, app)
-          }.to raise_error
+          }.to raise_error RuntimeError
         end
 
         it 'calls clear_app_on_physical_device' do
@@ -727,7 +727,7 @@ describe Calabash::IOS::Device do
         expect(JSON).to receive(:parse).with('[]').and_raise
         expect {
           device.send(:fetch_runtime_attributes)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'parses the body of the response to a ruby object' do
@@ -740,7 +740,7 @@ describe Calabash::IOS::Device do
         device.instance_variable_set(:@runtime_attributes, nil)
         expect {
           device.send(:expect_runtime_attributes_available, 'foo')
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it 'returns true if runtime_attributes are available' do
@@ -754,7 +754,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:expect_runtime_attributes_available).and_raise
         expect do
           device.device_family
-        end.to raise_error
+        end.to raise_error RuntimeError
       end
 
       it 'asks runtime_attributes for the value' do
@@ -770,7 +770,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:expect_runtime_attributes_available).and_raise
         expect do
           device.form_factor
-        end.to raise_error
+        end.to raise_error RuntimeError
       end
 
       it 'asks runtime_attributes for the value' do
@@ -791,7 +791,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:expect_runtime_attributes_available).and_raise
         expect do
           device.iphone_app_emulated_on_ipad?
-        end.to raise_error
+        end.to raise_error RuntimeError
       end
 
       it 'asks runtime_attributes for the value' do
@@ -813,7 +813,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:expect_runtime_attributes_available).and_raise
         expect do
           device.screen_dimensions
-        end.to raise_error
+        end.to raise_error RuntimeError
       end
 
       it 'asks runtime_attributes for the value' do
@@ -829,7 +829,7 @@ describe Calabash::IOS::Device do
         expect(device).to receive(:expect_runtime_attributes_available).and_raise
         expect do
           device.server_version
-        end.to raise_error
+        end.to raise_error RuntimeError
       end
 
       it 'asks runtime_attributes for the value' do

--- a/spec/lib/ios/device/uia_keyboard_mixin_spec.rb
+++ b/spec/lib/ios/device/uia_keyboard_mixin_spec.rb
@@ -118,7 +118,7 @@ describe Calabash::IOS::UIAKeyboardMixin::UIATypeStringHandler do
 
       expect do
         expect(handler.handle_error)
-      end.to raise_error
+      end.to raise_error RuntimeError
     end
 
     it "raises error and reports entire result if no 'error' in result hash" do
@@ -128,7 +128,7 @@ describe Calabash::IOS::UIAKeyboardMixin::UIATypeStringHandler do
 
       expect do
         expect(handler.handle_error)
-      end.to raise_error
+      end.to raise_error RuntimeError
     end
   end
 

--- a/spec/lib/wait_spec.rb
+++ b/spec/lib/wait_spec.rb
@@ -206,13 +206,13 @@ describe Calabash::Wait do
     it 'should take a screenshot if screenshot_on_error is true' do
       Calabash::Wait.default_options[:screenshot_on_error] = true
       expect(dummy).to receive(:screenshot_embed).once
-      expect{dummy.fail('Message')}.to raise_error
+      expect{dummy.fail('Message')}.to raise_error RuntimeError
     end
 
     it 'should not take a screenshot if screenshot_on_error is false' do
       Calabash::Wait.default_options[:screenshot_on_error] = false
       expect(dummy).not_to receive(:screenshot_embed)
-      expect{dummy.fail('Message')}.to raise_error
+      expect{dummy.fail('Message')}.to raise_error RuntimeError
     end
   end
 
@@ -320,7 +320,7 @@ describe Calabash::Wait do
                                                       "Not all queries #{dummy.parse_query_list(query)} matched a view")
     end
 
-    it 'should not fail a view is matched' do
+    it 'should not fail if a view is matched' do
       query = 'my query'
 
       expect(dummy).to receive(:views_exist?).with(query).and_return([{}])
@@ -444,7 +444,7 @@ describe Calabash::Wait do
       allow(dummy).to receive(:view_exists?).with(query).and_return(false)
       expect(dummy).to receive(:fail).with(Calabash::Wait::ViewNotFoundError, "Waited 30 seconds for #{dummy.parse_query_list(query)} to match a view").and_call_original
 
-      expect{dummy.wait_for_view(query)}.to raise_error
+      expect{dummy.wait_for_view(query)}.to raise_error Calabash::Wait::ViewNotFoundError
     end
 
     it 'should use defaults' do
@@ -524,7 +524,7 @@ describe Calabash::Wait do
                                            "Waited 30 seconds for #{dummy.parse_query_list(query)} to each match a view")
                            .and_call_original
 
-      expect{dummy.wait_for_views(query)}.to raise_error
+      expect{dummy.wait_for_views(query)}.to raise_error Calabash::Wait::ViewNotFoundError
     end
 
     it 'should fail if the views do not appear' do
@@ -536,7 +536,7 @@ describe Calabash::Wait do
                                            "Waited 30 seconds for #{dummy.parse_query_list(query)} to each match a view")
                            .and_call_original
 
-      expect{dummy.wait_for_views(*query)}.to raise_error
+      expect{dummy.wait_for_views(*query)}.to raise_error Calabash::Wait::ViewNotFoundError
     end
 
     it 'should use defaults' do
@@ -595,7 +595,7 @@ describe Calabash::Wait do
                                            "Waited 30 seconds for #{dummy.parse_query_list(query)} to not match any view")
                            .and_call_original
 
-      expect{dummy.wait_for_no_view(query)}.to raise_error
+      expect{dummy.wait_for_no_view(query)}.to raise_error Calabash::Wait::ViewFoundError
     end
 
     it 'should use defaults' do
@@ -665,7 +665,7 @@ describe Calabash::Wait do
                                            "Waited 30 seconds for #{dummy.parse_query_list(query)} to each not match any view")
                            .and_call_original
 
-      expect{dummy.wait_for_no_views(query)}.to raise_error
+      expect{dummy.wait_for_no_views(query)}.to raise_error Calabash::Wait::ViewFoundError
     end
 
     it 'should fail if the views do not disappear' do
@@ -677,7 +677,7 @@ describe Calabash::Wait do
                                            "Waited 30 seconds for #{dummy.parse_query_list(query)} to each not match any view")
                            .and_call_original
 
-      expect{dummy.wait_for_no_views(*query)}.to raise_error
+      expect{dummy.wait_for_no_views(*query)}.to raise_error Calabash::Wait::ViewFoundError
     end
 
     it 'should use defaults' do


### PR DESCRIPTION
### Motivation

It is a good thing I checked:  found two cases where we were masking a NameError incorrectly.
