### PR TITLE
iOS: implement uia

### DIFF
--- a/cucumber/ios/features/step_definitions/shared_steps.rb
+++ b/cucumber/ios/features/step_definitions/shared_steps.rb
@@ -14,7 +14,7 @@ Given(/^I see the (first|second|third) tab$/) do |tab|
 end
 
 Given(/^the app has launched$/) do
-  wait_for_view
+  wait_for_view('UITabBarButton')
 end
 
 And(/^I touch the text field$/) do

--- a/cucumber/ios/features/step_definitions/uia_steps.rb
+++ b/cucumber/ios/features/step_definitions/uia_steps.rb
@@ -1,0 +1,15 @@
+
+Then(/^I use UIA to touch the text field$/) do
+  wait_for_view("UITextField marked:'text'")
+  uia_with_main_window("elements()['first page'].textFields()['text'].tap()")
+end
+
+Then(/^I use UIA to type "([^"]*)"$/) do |text|
+  wait_for_keyboard
+  uia_with_app("keyboard().typeString('#{text}')")
+end
+
+Then(/^I use UIA to touch the Done button on the keyboard$/) do
+  wait_for_keyboard
+  uia_with_app("keyboard().buttons()['Done'].tap()")
+end

--- a/cucumber/ios/features/uia.feature
+++ b/cucumber/ios/features/uia.feature
@@ -4,7 +4,6 @@ Feature: UIA Automation Javascript API
   As a developer and tester
   I want to interact with the UIAutomation Javascript API
 
-@wip
   Scenario: Tapping
     Given I see the first tab
     Then I use UIA to touch the text field

--- a/cucumber/ios/features/uia.feature
+++ b/cucumber/ios/features/uia.feature
@@ -1,0 +1,14 @@
+@uia
+Feature: UIA Automation Javascript API
+  In order to test complicated behaviors
+  As a developer and tester
+  I want to interact with the UIAutomation Javascript API
+
+@wip
+  Scenario: Tapping
+    Given I see the first tab
+    Then I use UIA to touch the text field
+    And I wait for the keyboard
+    Then I use UIA to type "Hello"
+    And the text in the text field should be "Hello"
+    Then I use UIA to touch the Done button on the keyboard

--- a/lib/calabash/ios/device/uia_mixin.rb
+++ b/lib/calabash/ios/device/uia_mixin.rb
@@ -5,7 +5,7 @@ module Calabash
     module UIAMixin
 
       def evaluate_uia(script)
-        uia_serialize_and_call(script)
+        uia_route(script)
       end
     end
   end

--- a/spec/lib/ios/device/routes/uia_route_mixin_spec.rb
+++ b/spec/lib/ios/device/routes/uia_route_mixin_spec.rb
@@ -16,7 +16,6 @@ describe Calabash::IOS::Routes::UIARouteMixin do
         @run_loop = {:uia_strategy => :preferences}
         @uia_strategy = :preferences
       end
-
     end.new
   end
 
@@ -128,7 +127,8 @@ describe Calabash::IOS::Routes::UIARouteMixin do
     it "makes an http request on the 'uia' route" do
       expect(device).to receive(:make_uia_request).with('command', 'uia').and_return 'request'
       expect(device).to receive(:route_post_request).with('request').and_return response
-      expect(device).to receive(:route_handle_response).with(response, 'command').and_return({})
+      expect(device).to receive(:route_handle_response).with(response, 'command').and_return([])
+      expect(device).to receive(:handle_uia_results).with([], 'command').and_return({})
 
       expect(device.send(:uia_over_http, 'command', 'uia')).to be == {}
     end
@@ -221,6 +221,108 @@ describe Calabash::IOS::Routes::UIARouteMixin do
       expect(device).to receive(:uia_serialize_arguments).with([1, 2, 3]).and_return ['1', '2', '3']
       actual = device.send(:uia_serialize_command, :tapOffset, 1, 2, 3)
       expect(actual).to be == 'uia.tapOffset(1, 2, 3)'
+    end
+
+    describe '#expect_uia_result_is_an_array' do
+      it 'raises an error if not an array' do
+        expect {
+          device.send(:expect_uia_results_is_array, {})
+        }.to raise_error RuntimeError
+      end
+
+      it 'returns truthy if response is an array' do
+        expect(device.send(:expect_uia_results_is_array, [])).to be_truthy
+      end
+    end
+
+    describe '#expect_uia_result_has_one_element' do
+      describe 'raises an error when' do
+        it 'response has no elements' do
+          expect {
+            device.send(:expect_uia_results_has_one_element, [])
+          }.to raise_error RuntimeError
+        end
+
+        it 'response has more than one element' do
+          expect {
+            device.send(:expect_uia_results_has_one_element, [1, 2])
+          }.to raise_error RuntimeError
+        end
+      end
+
+      it 'returns truthy if response has one element' do
+        expect(device.send(:expect_uia_results_has_one_element, [1])).to be_truthy
+      end
+    end
+
+    describe '#expect_uia_result_element_is_hash' do
+      it 'raises an error if not an array' do
+        expect {
+          device.send(:expect_uia_response_element_is_hash, [])
+        }.to raise_error RuntimeError
+      end
+
+      it 'returns truthy if response element is a Hash' do
+        expect(device.send(:expect_uia_response_element_is_hash, {})).to be_truthy
+      end
+    end
+
+    describe '#expect_uia_result_has_valid_status_key' do
+      it 'raises an error if status key is not valid' do
+        hash = {'status' => 'invalid'}
+        expect {
+         device.send(:expect_uia_result_has_valid_status_key, hash,
+                     'response', 'command')
+        }.to raise_error RuntimeError
+      end
+
+      it 'returns truthy if response has a valid status key' do
+        hash = {'status' => 'error'}
+        actual = device.send(:expect_uia_result_has_valid_status_key, hash,
+                             'response', 'command')
+        expect(actual).to be_truthy
+
+        hash = {'status' => 'success' }
+        actual = device.send(:expect_uia_result_has_valid_status_key, hash,
+                             'response', 'command')
+        expect(actual).to be_truthy
+      end
+    end
+
+    describe '#expect_uia_result_has_value_key' do
+      it 'raises an error if there is no value key' do
+        expect {
+          device.send(:expect_uia_result_has_value_key, {},
+                      'response', 'command')
+        }.to raise_error RuntimeError
+      end
+
+      it 'returns truthy if there is a value key' do
+        hash = {'value' => 'a value'}
+        actual = device.send(:expect_uia_result_has_value_key, hash,
+                             'response', 'command')
+        expect(actual).to be_truthy
+      end
+    end
+
+    describe '#handle_uia_result_with_success' do
+      it 'value is array - returns an array' do
+        value = [1]
+        actual = device.send(:handle_uia_result_with_success, value)
+        expect(actual).to be == value
+      end
+
+      it 'value is :nil - returns [nil]' do
+        value = ':nil'
+        actual = device.send(:handle_uia_result_with_success, value)
+        expect(actual).to be == [nil]
+      end
+
+      it 'value is not an array - returns [value]' do
+        value = 'a'
+        actual = device.send(:handle_uia_result_with_success, value)
+        expect(actual).to be == ['a']
+      end
     end
   end
 end

--- a/spec/lib/ios/device/uia_mixin_spec.rb
+++ b/spec/lib/ios/device/uia_mixin_spec.rb
@@ -9,7 +9,7 @@ describe Calabash::IOS::UIAMixin do
 
   it '#evaluate_uia' do
     script = 'javascript'
-    expect(device).to receive(:uia_serialize_and_call).with(script).and_return :result
+    expect(device).to receive(:uia_route).with(script).and_return :result
 
     expect(device.evaluate_uia(script)).to be == :result
   end


### PR DESCRIPTION
### Motivation

```
  Scenario: Tapping
    Given I see the first tab
    Then I use UIA to touch the text field
    And I wait for the keyboard
    Then I use UIA to type "Hello"
    And the text in the text field should be "Hello"
    Then I use UIA to touch the Done button on the keyboard
```

Resolves: **Syntax errors in queries have outcome "success" instead of "failure"** [#374](https://github.com/calabash/calabash-ios/issues/374)