### PR TITLE
iOS: tap raises correct error if view is not found

### DIFF
--- a/cucumber/ios/features/gestures.feature
+++ b/cucumber/ios/features/gestures.feature
@@ -1,0 +1,11 @@
+@gestures
+Feature:  Gestures
+  In order to do things like touching, swiping, and dragging
+  As a developer
+  I want a Gesture API
+
+  @wip
+  Scenario: Tap waits for views
+    Given I see the first tab
+    When I tap a view that does not exist
+    Then a view-not-found wait error is raised

--- a/cucumber/ios/features/step_definitions/gestures_steps.rb
+++ b/cucumber/ios/features/step_definitions/gestures_steps.rb
@@ -1,0 +1,13 @@
+
+When(/^I tap a view that does not exist$/) do
+  begin
+    tap("view marked:'does not exist'")
+  rescue Calabash::Wait::ViewNotFoundError => e
+    @wait_view_not_found_error = e
+    ap e
+  end
+end
+
+Then(/^a view-not-found wait error is raised$/) do
+  expect(@wait_view_not_found_error).to be_an_instance_of Calabash::Wait::ViewNotFoundError
+end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -32,6 +32,14 @@ module Calabash
             define_method(:query) do |query, *args|
               reference_to_self.map_route(query, :query, *args)
             end
+
+            def to_s
+              '#<Calabash::IOS::GestureWaiter>'
+            end
+
+            def inspect
+              to_s
+            end
           end.new
         end.call(self)
       end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -28,7 +28,7 @@ module Calabash
       def gesture_waiter
         @gesture_waiter ||= lambda do |reference_to_self|
           Class.new do
-            include Calabash::Wait
+            include Calabash::IOS
             define_method(:query) do |query, *args|
               reference_to_self.map_route(query, :query, *args)
             end


### PR DESCRIPTION
### Motivation

Was raising:

```
   When I tap a view that does not exist      # features/step_definitions/gesstures_steps.rb:2
 undefined local variable or method `screenshot_embed' for
 #<#<Class:0x007f9fd410d940>:0x007f9fd410d710>
```

Now raises:

```
   #<Calabash::Wait::ViewNotFoundError: Waited 5 seconds for "view marked:'does not exist'" to match a view>
```