### PR TITLE
iOS: long press

### DIFF
--- a/cucumber/ios/features/gestures.feature
+++ b/cucumber/ios/features/gestures.feature
@@ -13,3 +13,11 @@ Feature:  Gestures
     Given I see the gestures tab
     When I double tap the box
     Then the gesture description changes to double tap
+
+  @wip
+  Scenario:  Long press
+    Given I see the gestures tab
+    When I long press the box for 1 second
+    Then the gesture description changes to long press
+    When I long press the box for 2 seconds
+    Then the gesture description changes to long press

--- a/cucumber/ios/features/gestures.feature
+++ b/cucumber/ios/features/gestures.feature
@@ -14,7 +14,6 @@ Feature:  Gestures
     When I double tap the box
     Then the gesture description changes to double tap
 
-  @wip
   Scenario:  Long press
     Given I see the gestures tab
     When I long press the box for 1 second

--- a/cucumber/ios/features/step_definitions/gestures_steps.rb
+++ b/cucumber/ios/features/step_definitions/gestures_steps.rb
@@ -22,7 +22,6 @@ When(/^I tap a view that does not exist$/) do
     tap("view marked:'does not exist'")
   rescue Calabash::Wait::ViewNotFoundError => e
     @wait_view_not_found_error = e
-    ap e
   end
 end
 

--- a/cucumber/ios/features/step_definitions/gestures_steps.rb
+++ b/cucumber/ios/features/step_definitions/gestures_steps.rb
@@ -43,3 +43,9 @@ Then(/^the gesture description changes to (double tap|long press)$/) do |type|
 
   wait_for_gesture(expected)
 end
+
+When(/^I long press the box for (\d+) seconds?$/) do |duration|
+  query = "view marked:'gestures box'"
+  long_press(query, {:duration => duration.to_i})
+  @last_long_press_duration = duration.to_i
+end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -21,12 +21,21 @@ module Calabash
       end
 
       def _double_tap(query, options={})
-        # 1. Find the view to touch
         view_to_touch = gesture_waiter.wait_for_view(query, options)
 
         offset = uia_center_of_view(view_to_touch)
 
         uia_serialize_and_call(:doubleTapOffset, offset)
+
+        Calabash::QueryResult.create([view_to_touch], query)
+      end
+
+      def _long_press(query, options={})
+        view_to_touch = gesture_waiter.wait_for_view(query, options)
+
+        offset = uia_center_of_view(view_to_touch)
+
+        uia_serialize_and_call(:touchHoldOffset, options[:duration], offset)
 
         Calabash::QueryResult.create([view_to_touch], query)
       end


### PR DESCRIPTION
### Motivation

```
  Scenario:  Long press
    Given I see the gestures tab
    When I long press the box for 1 second
    Then the gesture description changes to long press
    When I long press the box for 2 seconds
    Then the gesture description changes to long press
```