### PR TITLE
iOS: fixup wait for condition API

### DIFF
--- a/cucumber/ios/features/animations.feature
+++ b/cucumber/ios/features/animations.feature
@@ -19,6 +19,6 @@ Feature:  Animations
     Then I can wait for the indicator to stop
 
   Scenario: Call wait_for_animation with a nil query
-    When I pass an empty query to wait_for_animations
+    When I pass an empty query to wait_for_animations_in
     Then the app should not crash
     And an error should be raised

--- a/cucumber/ios/features/step_definitions/animations_steps.rb
+++ b/cucumber/ios/features/step_definitions/animations_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I wait for all animations to stop$/) do
   # Test for:  https://github.com/calabash/calabash-ios-server/pull/142
   # When checking for no animation, ignore animations with trivially short durations
-  wait_for_none_animating(4)
+  wait_for_animations(4)
 end
 
 And(/^I have started an animation that lasts (\d+) seconds$/) do |duration|
@@ -15,7 +15,7 @@ end
 Then(/^I can wait for the animation to stop$/) do
   timeout = @last_animation_duration + 1
 
-  wait_for_animations(@last_animation_query, timeout)
+  wait_for_animations_in(@last_animation_query, timeout)
 end
 
 And(/^I start the network indicator for (\d+) seconds$/) do |duration|
@@ -30,7 +30,7 @@ end
 
 When(/^I pass an empty query to wait_for_animations$/) do
   begin
-    wait_for_animations('')
+    wait_for_animations_in('')
   rescue ArgumentError => _
     @runtime_error_raised = true
   end

--- a/cucumber/ios/features/step_definitions/animations_steps.rb
+++ b/cucumber/ios/features/step_definitions/animations_steps.rb
@@ -28,7 +28,7 @@ Then(/^I can wait for the indicator to stop$/) do
   wait_for_no_network_indicator(timeout)
 end
 
-When(/^I pass an empty query to wait_for_animations$/) do
+When(/^I pass an empty query to wait_for_animations_in$/) do
   begin
     wait_for_animations_in('')
   rescue ArgumentError => _

--- a/lib/calabash/ios/conditions.rb
+++ b/lib/calabash/ios/conditions.rb
@@ -7,7 +7,7 @@ module Calabash
       # @param [Numeric] timeout How long to wait for the animations to stop.
       # @return [nil] when the condition is satisfied
       # @raise [Calabash::Cucumber::WaitHelpers::WaitError] when the timeout is exceeded
-      def wait_for_none_animating(timeout=2)
+      def wait_for_animations(timeout=2)
         message = "Timed out after #{timeout} seconds wait for all views to stop animating."
 
         wait_for_condition(CALABASH_CONDITIONS[:none_animating],
@@ -22,7 +22,7 @@ module Calabash
       # @param [Numeric] timeout How long to wait for the animations to stop.
       # @return [nil] When the condition is satisfied.
       # @raise [Calabash::Wait::TimeoutError] When the timeout is exceeded.
-      def wait_for_animations(query, timeout=2)
+      def wait_for_animations_in(query, timeout=2)
 
         if query.nil? || query == ''
           raise ArgumentError, 'Query argument must not be nil or the empty string'

--- a/lib/calabash/ios/conditions.rb
+++ b/lib/calabash/ios/conditions.rb
@@ -12,8 +12,8 @@ module Calabash
 
         wait_for_condition(CALABASH_CONDITIONS[:none_animating],
                            timeout,
-                           message,
-                           query)
+                           message)
+
       end
 
       # Waits for all elements matching `query` to stop animating.


### PR DESCRIPTION
### Motivation

```
  @backdoor
  Scenario: Start an animation and wait for it to finish
    And I have started an animation that lasts 4 seconds
    Then I can wait for the animation to stop

  @network_indicator
  @backdoor
  Scenario: Start the network indicator and wait for it to finish
    And I start the network indicator for 4 seconds
    Then I can wait for the indicator to stop

  Scenario: Call wait_for_animation with a nil query
    When I pass an empty query to wait_for_animations_in
    Then the app should not crash
    And an error should be raised
```