### PR TITLE
iOS: conditions API fixup

### DIFF
--- a/lib/calabash/ios/conditions.rb
+++ b/lib/calabash/ios/conditions.rb
@@ -68,7 +68,7 @@ module Calabash
       #  NO_NETWORK_INDICATOR
       # @return [nil] When the condition is satisfied.
       # @raise [Calabash::Wait::TimeoutError] When the timeout is exceeded.
-      def wait_for_condition(condition, timeout, timeout_message, query=nil)
+      def wait_for_condition(condition, timeout, timeout_message, query='*')
         unless Device.default.condition_route(condition, timeout, query)
           raise Calabash::Wait::TimeoutError, timeout_message
         end

--- a/lib/calabash/ios/conditions.rb
+++ b/lib/calabash/ios/conditions.rb
@@ -72,7 +72,7 @@ module Calabash
         unless Device.default.condition_route(condition, timeout, query)
           raise Calabash::Wait::TimeoutError, timeout_message
         end
-        nil
+        true
       end
     end
   end


### PR DESCRIPTION
### Motivation

* Default query should be '*' not nil, which will crash the app.
* Return true when condition is met without raising.