### PR TITLE
Wait: Reduce the default retry frequency

### DIFF
--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -18,7 +18,7 @@ module Calabash
             end,
 
             # default polling frequency for waiting
-            retry_frequency: 0.3,
+            retry_frequency: 0.1,
 
             # default exception type to raise when the timeout is exceeded
             exception_class: Calabash::Wait::TimeoutError,

--- a/spec/lib/wait_spec.rb
+++ b/spec/lib/wait_spec.rb
@@ -20,7 +20,7 @@ describe Calabash::Wait do
 
       expect(default_options[:timeout]).to eq(Calabash::Environment::WAIT_TIMEOUT)
       expect(default_options[:message].call({timeout: 10})).to eq("Timed out after waiting for 10 seconds...")
-      expect(default_options[:retry_frequency]).to eq(0.3)
+      expect(default_options[:retry_frequency]).to eq(0.1)
       expect(default_options[:exception_class]).to eq(Calabash::Wait::TimeoutError)
       expect(default_options[:screenshot_on_error]).to eq(true)
 


### PR DESCRIPTION
### Motivation

The default 0.3 is too long.

@TobiasRoikjer Agreed?
