### PR TITLE
iOS: Device: #dump: Should have longer timeout

### DIFF
--- a/lib/calabash/device.rb
+++ b/lib/calabash/device.rb
@@ -85,7 +85,7 @@ module Calabash
     def dump
       request = HTTP::Request.new('/dump')
 
-      JSON.parse(http_client.get(request).body)
+      JSON.parse(http_client.get(request, timeout: 60).body)
     end
 
     # @!visibility private


### PR DESCRIPTION
Dumping can take a while, especially for WKWebViews on iOS