### PR TITLE
iOS Pan part 2

### DIFF
--- a/cucumber/ios/config/cucumber.yml
+++ b/cucumber/ios/config/cucumber.yml
@@ -17,3 +17,5 @@ app:           CAL_APP="<%= APP %>"
 
 simulator:     -p app -p formatter
 default:       -p simulator
+
+device:        -p formatter CAL_APP=./CalSmoke-cal.ipa

--- a/cucumber/ios/features/pan.feature
+++ b/cucumber/ios/features/pan.feature
@@ -1,0 +1,23 @@
+@pan
+Feature: Pan
+  In order to perform swipes
+  As a developer
+  I want a Pan API
+
+Background: Navigate to the scrolls page
+  Given I see the scrolls tab
+
+Scenario: Left-to-right screen pan in portrait
+  When I touch the table views row
+  Then I see the table views page
+  When I pan left on the screen
+  Then I go back to the Scrolls page
+
+  @wip
+Scenario: Left-to-right screen pan in landscape
+  And I rotate so the home button is on the right
+  When I touch the collection views row
+  Then I see the collection views page
+  When I pan left on the screen
+  Then I go back to the Scrolls page
+

--- a/cucumber/ios/features/pan.feature
+++ b/cucumber/ios/features/pan.feature
@@ -13,11 +13,17 @@ Scenario: Left-to-right screen pan in portrait
   When I pan left on the screen
   Then I go back to the Scrolls page
 
-  @wip
 Scenario: Left-to-right screen pan in landscape
   And I rotate so the home button is on the right
   When I touch the collection views row
   Then I see the collection views page
   When I pan left on the screen
   Then I go back to the Scrolls page
+
+Scenario: Panning on a scroll view
+  When I touch the scroll views row
+  Then I see the scroll views page
+  When I pan to the cayenne box on the simulator
+  Then I expect an error to be raised about dragInsideWithOptions
+  But I can pan to the cayenne box on the device
 

--- a/cucumber/ios/features/step_definitions/pan_steps.rb
+++ b/cucumber/ios/features/step_definitions/pan_steps.rb
@@ -1,0 +1,12 @@
+
+When(/^I pan left on the screen$/) do
+  to = percent(0, 50)
+  from = percent(75, 50)
+  pan('*', to, from)
+  wait_for_animations
+end
+
+Then(/^I go back to the Scrolls page$/) do
+  query = "view marked:'scrolls page'"
+  wait_for_view(query)
+end

--- a/cucumber/ios/features/step_definitions/pan_steps.rb
+++ b/cucumber/ios/features/step_definitions/pan_steps.rb
@@ -10,3 +10,28 @@ Then(/^I go back to the Scrolls page$/) do
   query = "view marked:'scrolls page'"
   wait_for_view(query)
 end
+
+When(/^I pan to the cayenne box on the simulator$/) do
+  if simulator?
+    query = "UIScrollView marked:'scroll'"
+
+    expect do
+      pan(query, percent(80, 80), percent(10, 20))
+    end.to raise_error RuntimeError,
+    /Apple's public UIAutomation API `dragInsideWithOptions`/
+
+  end
+end
+
+Then(/^I expect an error to be raised about dragInsideWithOptions$/) do
+  # see step above
+end
+
+But(/^I can pan to the cayenne box on the device$/) do
+  if physical_device?
+    query = "UIScrollView marked:'scroll'"
+    pan(query, percent(80, 80), percent(10, 20))
+    wait_for_animations_in(query)
+    wait_for_view("view marked:'cayenne'")
+  end
+end

--- a/cucumber/ios/features/step_definitions/scroll_steps.rb
+++ b/cucumber/ios/features/step_definitions/scroll_steps.rb
@@ -22,6 +22,7 @@ When(/^I touch the (collection|table|scroll) views row$/) do |row_name|
   query = "UITableViewCell marked:'#{row_name} views row'"
 
   tap(query)
+  wait_for_animations
 end
 
 Then(/^I see the (collection|table|scroll) views page$/) do |page_name|

--- a/cucumber/ios/features/step_definitions/scroll_steps.rb
+++ b/cucumber/ios/features/step_definitions/scroll_steps.rb
@@ -5,7 +5,6 @@ module CalSmokeApp
       loop do
         break if visible_block.call || count == 3
         scroll(query, direction)
-        wait_for_animations
         count = count + 1;
       end
     end
@@ -23,7 +22,6 @@ When(/^I touch the (collection|table|scroll) views row$/) do |row_name|
   query = "UITableViewCell marked:'#{row_name} views row'"
 
   tap(query)
-  wait_for_animations
 end
 
 Then(/^I see the (collection|table|scroll) views page$/) do |page_name|
@@ -39,7 +37,6 @@ Then(/^I scroll the logos collection to the steam icon by mark$/) do
   }
 
   scroll_to_item(query, 'steam', options)
-  wait_for_animations
 end
 
 Then(/^I scroll the logos collection to the github icon by index$/) do
@@ -51,7 +48,6 @@ Then(/^I scroll the logos collection to the github icon by index$/) do
   }
 
   scroll_to_item(query, 13, 0, options)
-  wait_for_animations
 end
 
 Then(/^I scroll up on the logos collection to the android icon$/) do
@@ -74,7 +70,6 @@ Then(/^I scroll the colors collection to the middle of the purple boxes$/) do
   }
 
   scroll_to_item(query, 12, 4, options)
-  wait_for_animations
 end
 
 Then(/^I scroll the logos table to the steam row by mark$/) do
@@ -85,7 +80,6 @@ Then(/^I scroll the logos table to the steam row by mark$/) do
   }
 
   scroll_to_row_with_mark(query, 'steam', options)
-  wait_for_animations
 end
 
 Then(/^I scroll the logos table to the github row by index$/) do
@@ -96,7 +90,6 @@ Then(/^I scroll the logos table to the github row by index$/) do
   }
 
   scroll_to_row(query, 13, options)
-  wait_for_animations
 end
 
 Then(/^I scroll up on the logos table to the android row$/) do
@@ -116,7 +109,6 @@ Then(/^I center the cayenne box to the middle$/) do
   wait_for_view(query)
 
   query(query, :centerContentToBounds)
-  wait_for_animations
 
   query = "view marked:'cayenne'"
   wait_for_view(query)

--- a/cucumber/ios/features/support/ideviceinstaller.rb
+++ b/cucumber/ios/features/support/ideviceinstaller.rb
@@ -1,0 +1,66 @@
+ require 'fileutils'
+ class Calabash::IOS::Device
+
+   def app_installed_on_physical_device?(application, device_udid)
+     out = `/usr/local/bin/ideviceinstaller --udid #{device_udid} --list-apps`
+     out.split(/\s/).include? application.identifier
+   end
+
+   def install_app_on_physical_device(application, device_udid)
+
+     if app_installed_on_physical_device?(application, device_udid)
+       uninstall_app_on_physical_device(application, device_udid)
+     end
+
+     args =
+           [
+                 '--udid', device_udid,
+                 '--install', application.path
+           ]
+
+     log = FileUtils.touch('./ideviceinstaller.log')
+     system('/usr/local/bin/ideviceinstaller', *args, {:out => log})
+
+     exit_code = $?
+     unless exit_code == 0
+       raise "Could not install the app (#{exit_code}).  See #{File.expand_path(log)}"
+     end
+     true
+   end
+
+   def uninstall_app_on_physical_device(application, device_udid)
+
+     if app_installed_on_physical_device?(application, device_udid)
+
+       args =
+             [
+                   '--udid', device_udid,
+                   '--uninstall', application.identifier
+             ]
+
+       log = FileUtils.touch('./ideviceinstaller.log')
+       system('/usr/local/bin/ideviceinstaller', *args, {:out => log})
+
+       exit_code = $?
+       unless exit_code == 0
+         raise "Could not uninstall the app (#{exit_code}).  See #{File.expand_path(log)}"
+       end
+     end
+     true
+   end
+
+   def ensure_app_installed_on_physical_device(application, device_udid)
+     unless app_installed_on_physical_device?(application, device_udid)
+       install_app_on_physical_device(application, device_udid)
+     end
+     true
+   end
+
+   # The only way to clear the data is to uninstall the app.
+   def clear_app_data_on_physical_device(application, device_udid)
+     if app_installed_on_physical_device?(application, device_udid)
+       install_app_on_physical_device(application, device_udid)
+     end
+     true
+   end
+ end

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -25,6 +25,7 @@ module Calabash
     require 'calabash/ios/console_helpers'
     require 'calabash/ios/uia'
     require 'calabash/ios/scroll'
+    require 'calabash/ios/runtime'
 
     include Calabash::IOS::Conditions
     include Calabash::IOS::Orientation
@@ -32,6 +33,7 @@ module Calabash
     include Calabash::IOS::Text
     include Calabash::IOS::UIA
     include Calabash::IOS::Scroll
+    include Calabash::IOS::Runtime
 
   end
 end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -84,14 +84,6 @@ module Calabash
       # `Device.default.simulator? && !Device.ios6?`, but I haven't checked on
       # iOS 9 yet, so I will leave the condition out.
       def _pan(query, from, to, options={})
-        if Device.default.simulator?
-          message = [
-                "Apple's public UIAutomation API `dragInsideWithOptions` is broken for iOS Simulators >= 7",
-                'Try using the scroll_* methods or test on a device.'
-          ].join("\n")
-
-          raise message
-        end
 
         begin
           _expect_valid_duration(options)
@@ -99,7 +91,33 @@ module Calabash
           raise ArgumentError e
         end
 
-        view_to_pan = _gesture_waiter.wait_for_view(query, options)
+        gesture_waiter = _gesture_waiter
+        view_to_pan = gesture_waiter.wait_for_view(query, options)
+
+        if Device.default.simulator?
+
+          should_raise = false
+
+          content_offset = gesture_waiter.query(query, :contentOffset).first
+
+          if content_offset != '*****'
+            # Panning on anything with a content offset is broken.
+            should_raise = true
+          else
+            # TODO: Identify other conditions
+            # TODO: Can we detect UITableViewCells?
+            # The gist is that if the view is a UIScrollView or in a UIScrollView
+            # dragInsideWithOptions does not work
+          end
+
+          if should_raise
+            message = [
+                  "Apple's public UIAutomation API `dragInsideWithOptions` is broken for iOS Simulators >= 7",
+                  'Try using the scroll_* methods or test on a device.'
+            ].join("\n")
+            raise message
+          end
+        end
 
         rect = view_to_pan['rect']
 

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -86,8 +86,8 @@ module Calabash
       def _pan(query, from, to, options={})
         if Device.default.simulator?
           message = [
-                "Apple's UIAutomation `dragInsideWithOptions` API is broken for iOS > 7",
-                'If you are trying to scroll on a UITableView or UICollectionView, try using the scroll_* methods'
+                "Apple's public UIAutomation API `dragInsideWithOptions` is broken for iOS Simulators >= 7",
+                'Try using the scroll_* methods or test on a device.'
           ].join("\n")
 
           raise message

--- a/lib/calabash/ios/runtime.rb
+++ b/lib/calabash/ios/runtime.rb
@@ -1,0 +1,15 @@
+module Calabash
+  module IOS
+    module Runtime
+
+      # @todo Complete and document the Runtime API
+      def simulator?
+        Calabash::IOS::Device.default.simulator?
+      end
+
+      def physical_device?
+        Calabash::IOS::Device.default.physical_device?
+      end
+    end
+  end
+end

--- a/lib/calabash/ios/scroll.rb
+++ b/lib/calabash/ios/scroll.rb
@@ -77,7 +77,7 @@ module Calabash
           fail("Expected '#{query}' to match a UIScrollView or a subclass")
         end
 
-        wait_for_animations
+        wait_for_animations_in(query)
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end
@@ -165,7 +165,7 @@ module Calabash
           fail(message)
         end
 
-        wait_for_animations
+        wait_for_animations_in(query)
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end
@@ -252,7 +252,7 @@ module Calabash
           fail(message)
         end
 
-        wait_for_animations
+        wait_for_animations_in(query)
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end
@@ -346,7 +346,7 @@ module Calabash
           fail(message)
         end
 
-        wait_for_animations
+        wait_for_animations_in(query)
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end
@@ -440,7 +440,7 @@ module Calabash
           fail(message)
         end
 
-        wait_for_animations
+        wait_for_animations_in(query)
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end

--- a/lib/calabash/ios/scroll.rb
+++ b/lib/calabash/ios/scroll.rb
@@ -77,6 +77,8 @@ module Calabash
           fail("Expected '#{query}' to match a UIScrollView or a subclass")
         end
 
+        wait_for_animations
+
         Calabash::QueryResult.create([view_to_scroll], query)
       end
 
@@ -163,6 +165,8 @@ module Calabash
           fail(message)
         end
 
+        wait_for_animations
+
         Calabash::QueryResult.create([view_to_scroll], query)
       end
 
@@ -247,6 +251,8 @@ module Calabash
           ].join("\n")
           fail(message)
         end
+
+        wait_for_animations
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end
@@ -340,6 +346,8 @@ module Calabash
           fail(message)
         end
 
+        wait_for_animations
+
         Calabash::QueryResult.create([view_to_scroll], query)
       end
 
@@ -431,6 +439,8 @@ module Calabash
           ].join("\n")
           fail(message)
         end
+
+        wait_for_animations
 
         Calabash::QueryResult.create([view_to_scroll], query)
       end

--- a/spec/lib/ios/scroll_spec.rb
+++ b/spec/lib/ios/scroll_spec.rb
@@ -16,6 +16,7 @@ describe Calabash::IOS::Scroll do
       def to_s; '#<Cucumber World>'; end
       def inspect; to_s; end
       def screenshot_embed; ; end
+      def wait_for_animations; ; end
     end.new
   end
 

--- a/spec/lib/ios/scroll_spec.rb
+++ b/spec/lib/ios/scroll_spec.rb
@@ -16,7 +16,7 @@ describe Calabash::IOS::Scroll do
       def to_s; '#<Cucumber World>'; end
       def inspect; to_s; end
       def screenshot_embed; ; end
-      def wait_for_animations; ; end
+      def wait_for_animations_in(_); ; end
     end.new
   end
 


### PR DESCRIPTION
### Motivation

Pan works on iOS Simulators, but never in UIScrollView or UIScrollView subclasses.

```
Scenario: Left-to-right screen pan in portrait
  When I touch the table views row
  Then I see the table views page
  When I pan left on the screen
  Then I go back to the Scrolls page

Scenario: Left-to-right screen pan in landscape
  And I rotate so the home button is on the right
  When I touch the collection views row
  Then I see the collection views page
  When I pan left on the screen
  Then I go back to the Scrolls page

Scenario: Panning on a scroll view
  When I touch the scroll views row
  Then I see the scroll views page
  When I pan to the cayenne box on the simulator
  Then I expect an error to be raised about dragInsideWithOptions
  But I can pan to the cayenne box on the device
```