### PR TITLE
Improve the console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ lib/calabash/android/lib/AndroidManifest.xml
 
 # irb
 .irb-history
+.pry-history
 
 # screenshots that might be produced during testing
 *screenshots*

--- a/cucumber/android/features/support/env.rb
+++ b/cucumber/android/features/support/env.rb
@@ -11,4 +11,6 @@ Calabash::Application.default = Calabash::Android::Application.default_from_envi
 
 unless Calabash::Environment.xamarin_test_cloud?
   require 'pry'
+  Pry.config.history.file = '.pry-history'
+  require 'pry-nav'
 end

--- a/cucumber/ios/.irbrc
+++ b/cucumber/ios/.irbrc
@@ -1,37 +1,6 @@
 require 'irb/completion'
 require 'irb/ext/save-history'
 
-module Calabash
-  module IRBRC
-    def self.with_warn_suppressed(&block)
-      warn_level = $VERBOSE
-      begin
-        $VERBOSE = nil
-        block.call
-      ensure
-        $VERBOSE = warn_level
-      end
-    end
-
-    def self.message_of_the_day
-      motd = ["Let's get this done!", 'Ready to rumble.', 'Enjoy.', 'Remember to breathe.',
-              'Take a deep breath.', "Isn't it time for a break?", 'Can I get you a coffee?',
-              'What is a calabash anyway?', 'Smile! You are on camera!', 'Let op! Wild Rooster!',
-              "Don't touch that button!", "I'm gonna take this to 11.", 'Console. Engaged.',
-              'Your wish is my command.', 'This console session was created just for you.',
-              'Den som jager to harer, får ingen.', 'Uti, non abuti.', 'Non Satis Scire',
-              'Nullius in verba', 'Det ka æn jå væer ei jált']
-
-      begin
-        puts "Calabash #{Calabash::VERSION} says: '#{motd.shuffle.first}'"
-      rescue NameError => _
-        puts "Calabash says: '#{motd.shuffle.first}'"
-      end
-    end
-  end
-end
-
-
 IRB.conf[:SAVE_HISTORY] = 100
 IRB.conf[:HISTORY_FILE] = '.irb-history'
 
@@ -39,76 +8,69 @@ ARGV.concat [ '--readline',
               '--prompt-mode',
               'simple']
 
-has_skipped_requires = false
-
-Calabash::IRBRC.with_warn_suppressed do
-  begin
-    require 'awesome_print'
-    AwesomePrint.irb!
-  rescue LoadError => _
-    puts 'INFO: Skipping awesome_print dependency'
-    has_skipped_requires = true
-  end
-
-  begin
-    require 'pry'
-  rescue LoadError => _
-    puts 'INFO: Skipping pry dependency'
-    has_skipped_requires = true
-  end
-
-  begin
-    require 'pry-nav'
-  rescue LoadError => _
-    puts 'INFO: Skipping pry-nav dependency'
-    has_skipped_requires = true
-  end
-
-  begin
-    abp = File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
-                                     'spec', 'resources', 'ios',
-                                     'CalSmoke-cal.app'))
-    ENV['CAL_APP'] = abp
-    require 'calabash/ios'
-    extend Calabash::IOS
-    extend Calabash::ConsoleHelpers
-
-    Calabash::Application.default = Calabash::IOS::Application.new(abp)
-
-    identifier = Calabash::IOS::Device.default_identifier_for_application(Calabash::Application.default)
-    server = Calabash::IOS::Server.default
-
-    Calabash::Device.default = Calabash::IOS::Device.new(identifier, server)
-
-    embed_lambda = lambda do |*_|
-      Calabash::Logger.info 'Embed is not available in the console.'
-    end
-
-    Calabash.new_embed_method!(embed_lambda)
-  rescue LoadError => _
-    puts 'INFO: Skipping calabash dependency'
-    has_skipped_requires = true
-  end
+begin
+  require 'pry'
+  Pry.config.history.file = '.pry-history'
+  require 'pry-nav'
+rescue LoadError => _
 
 end
 
-
-if has_skipped_requires
-  puts 'INFO: Some requires have been skipped.'
-  puts 'INFO: Run with bundle exec if you need these dependencies'
+begin
+  require 'awesome_print'
+  AwesomePrint.irb!
+rescue LoadError => e
+  msg = ["Caught a LoadError: could not load 'awesome_print'",
+         "#{e}",
+         '',
+         'Use bundler (recommended) or uninstall awesome_print.',
+         '',
+         '# Use bundler (recommended)',
+         '$ bundle update',
+         '$ bundle exec calabash console [path to apk]',
+         '',
+         '# Uninstall',
+         '$ gem update --system',
+         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+  puts msg
+  exit(1)
 end
 
+begin
+
+  require 'calabash/ios'
+
+  extend Calabash::IOS
+  extend Calabash::ConsoleHelpers
+
+  Calabash::IOS.setup_defaults!
+
+  embed_lambda = lambda do |*_|
+    Calabash::Logger.info 'Embed is not available in the console.'
+    true
+  end
+
+  Calabash.new_embed_method!(embed_lambda)
+
+  Calabash::Screenshot.screenshot_directory_prefix = 'console_'
+
+  message_of_the_day
+rescue Exception => e
+  puts 'Unable to start console:'
+  puts "#{e.class}: #{e.message}"
+  puts "#{e.backtrace.join("\n")}"
+  exit(1)
+end
 
 def start_host(options={})
-  start_app(options.merge({:uia_strategy => :host}))
+    start_app(options.merge({:uia_strategy => :host}))
 end
 
 def start_shared(options={})
-  start_app(options.merge({:uia_strategy => :shared_element}))
+    start_app(options.merge({:uia_strategy => :shared_element}))
 end
 
 def start_prefs(options={})
-  start_app(options.merge({:uia_strategy => :preferences}))
+    start_app(options.merge({:uia_strategy => :preferences}))
 end
-
-Calabash::IRBRC.message_of_the_day
+end

--- a/cucumber/ios/.irbrc
+++ b/cucumber/ios/.irbrc
@@ -54,6 +54,7 @@ begin
 
   Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
+  puts_console_details
   message_of_the_day
 rescue Exception => e
   puts 'Unable to start console:'
@@ -72,5 +73,4 @@ end
 
 def start_prefs(options={})
     start_app(options.merge({:uia_strategy => :preferences}))
-end
 end

--- a/cucumber/ios/features/support/env.rb
+++ b/cucumber/ios/features/support/env.rb
@@ -11,4 +11,6 @@ Calabash::Device.default = Calabash::IOS::Device.new(identifier, server)
 
 unless Calabash::Environment.xamarin_test_cloud?
   require 'pry'
+  Pry.config.history.file = '.pry-history'
+  require 'pry-nav'
 end

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -42,6 +42,7 @@ begin
 
     Calabash.new_embed_method!(lambda {|*_| Calabash::Logger.info 'Embed is not available in the console.'})
     Calabash::Screenshot.screenshot_directory_prefix = 'console_'
+    message_of_the_day
 rescue Exception => e
     puts 'Unable to start console:'
     puts "#{e.class}: #{e.message}"

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -11,11 +11,6 @@ ARGV.concat [ '--readline',
 begin
   require 'pry'
   Pry.config.history.file = '.pry_history'
-rescue LoadError => _
-
-end
-
-begin
   require 'pry-nav'
 rescue LoadError => _
 

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -40,7 +40,12 @@ begin
 
     Calabash::Android.setup_defaults!
 
-    Calabash.new_embed_method!(lambda {|*_| Calabash::Logger.info 'Embed is not available in the console.'})
+    embed_lambda = lambda do |*_|
+      Calabash::Logger.info 'Embed is not available in the console.'
+    end
+
+    Calabash.new_embed_method!(embed_lambda)
+
     Calabash::Screenshot.screenshot_directory_prefix = 'console_'
     message_of_the_day
 rescue Exception => e

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -22,47 +22,46 @@ rescue LoadError => _
 end
 
 begin
+  require 'awesome_print'
+  AwesomePrint.irb!
+rescue LoadError => e
+  msg = ["Caught a LoadError: could not load 'awesome_print'",
+         "#{e}",
+         '',
+         'Use bundler (recommended) or uninstall awesome_print.',
+         '',
+         '# Use bundler (recommended)',
+         '$ bundle update',
+         '$ bundle exec calabash console [path to apk]',
+         '',
+         '# Uninstall',
+         '$ gem update --system',
+         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+  puts msg
+  exit(1)
+end
 
-    begin
-        require 'awesome_print'
-    rescue LoadError => e
-        msg = ["Caught a LoadError: could not load 'awesome_print'",
-             "#{e}",
-             '',
-             'Use bundler (recommended) or uninstall awesome_print.',
-             '',
-             '# Use bundler (recommended)',
-             '$ bundle update',
-             '$ bundle exec calabash console [path to apk]',
-             '',
-             '# Uninstall',
-             '$ gem update --system',
-             '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
-        puts msg
-        exit(1)
-    end
+begin
+  require 'calabash/android'
 
-    AwesomePrint.irb!
+  extend Calabash::Android
+  extend Calabash::ConsoleHelpers
 
-    require 'calabash/android'
+  Calabash::Android.setup_defaults!
 
-    extend Calabash::Android
-    extend Calabash::ConsoleHelpers
+  embed_lambda = lambda do |*_|
+    Calabash::Logger.info 'Embed is not available in the console.'
+    true
+  end
 
-    Calabash::Android.setup_defaults!
+  Calabash.new_embed_method!(embed_lambda)
 
-    embed_lambda = lambda do |*_|
-      Calabash::Logger.info 'Embed is not available in the console.'
-      true
-    end
+  Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
-    Calabash.new_embed_method!(embed_lambda)
-
-    Calabash::Screenshot.screenshot_directory_prefix = 'console_'
-    message_of_the_day
+  message_of_the_day
 rescue Exception => e
-    puts 'Unable to start console:'
-    puts "#{e.class}: #{e.message}"
-    puts "#{e.backtrace.join("\n")}"
-    exit(1)
+  puts 'Unable to start console:'
+  puts "#{e.class}: #{e.message}"
+  puts "#{e.backtrace.join("\n")}"
+  exit(1)
 end

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -9,6 +9,19 @@ ARGV.concat [ '--readline',
               'simple']
 
 begin
+  require 'pry'
+  Pry.config.history.file = '.pry_history'
+rescue LoadError => _
+
+end
+
+begin
+  require 'pry-nav'
+rescue LoadError => _
+
+end
+
+begin
 
     begin
         require 'awesome_print'

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -10,7 +10,7 @@ ARGV.concat [ '--readline',
 
 begin
   require 'pry'
-  Pry.config.history.file = '.pry_history'
+  Pry.config.history.file = '.pry-history'
   require 'pry-nav'
 rescue LoadError => _
 

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -53,6 +53,7 @@ begin
 
   Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
+  puts_console_details
   message_of_the_day
 rescue Exception => e
   puts 'Unable to start console:'

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -42,6 +42,7 @@ begin
 
     embed_lambda = lambda do |*_|
       Calabash::Logger.info 'Embed is not available in the console.'
+      true
     end
 
     Calabash.new_embed_method!(embed_lambda)

--- a/lib/calabash/android/lib/.irbrc
+++ b/lib/calabash/android/lib/.irbrc
@@ -1,6 +1,14 @@
+require 'irb/completion'
+require 'irb/ext/save-history'
+
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = '.irb-history'
+
+ARGV.concat [ '--readline',
+              '--prompt-mode',
+              'simple']
+
 begin
-    require 'irb/completion'
-    require 'irb/ext/save-history'
 
     begin
         require 'awesome_print'
@@ -22,16 +30,6 @@ begin
     end
 
     AwesomePrint.irb!
-
-    ARGV.concat [ '--readline',
-                  '--prompt-mode',
-                  'simple']
-
-    # 50 entries in the list
-    IRB.conf[:SAVE_HISTORY] = 50
-
-    # Store results in home directory with specified file name
-    IRB.conf[:HISTORY_FILE] = '.irb-history'
 
     require 'calabash/android'
 

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -62,6 +62,19 @@ module Calabash
     end
 
     # !@visibility private
+    def puts_console_details
+      puts ''
+      puts Color.blue('#             =>  Useful functions.  <=             #')
+      puts Color.cyan('>     ids => List all the visible ids.')
+      puts Color.cyan('> classes => List all the visible classes.')
+      puts Color.cyan(">    tree => The app's visible view hierarchy.")
+      puts Color.cyan('>    copy => Copy console commands to the Clipboard.')
+      puts Color.cyan('> verbose => Turn debug logging on.')
+      puts Color.cyan('>   quiet => Turn debug logging off.')
+      puts ''
+    end
+
+    # !@visibility private
     def self.save_old_readline_history
       file_name = IRB.conf[:HISTORY_FILE]
 

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -11,20 +11,6 @@ module Calabash
       true
     end
 
-    # !@visibility private
-    def self.save_old_readline_history
-      file_name = IRB.conf[:HISTORY_FILE]
-
-      if File.exist?(file_name)
-        @@start_readline_history = File.readlines(file_name).map(&:chomp)
-      end
-    end
-
-    # !@visibility private
-    def self.extended(base)
-      save_old_readline_history
-    end
-
     # List the visible element classes.
     def classes
       query("*").map{|e| e['class']}.uniq
@@ -45,6 +31,20 @@ module Calabash
     def clear
       ConsoleHelpers.clear
       true
+    end
+
+    # !@visibility private
+    def self.save_old_readline_history
+      file_name = IRB.conf[:HISTORY_FILE]
+
+      if File.exist?(file_name)
+        @@start_readline_history = File.readlines(file_name).map(&:chomp)
+      end
+    end
+
+    # !@visibility private
+    def self.extended(base)
+      save_old_readline_history
     end
 
     # !@visibility private

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -2,7 +2,8 @@ require 'clipboard'
 
 module Calabash
 
-  # Helper methods for the Calabash console.
+  # Methods you can use in the Calabash console to help you
+  # interact with your app.
   module ConsoleHelpers
 
     # Outputs all visible elements as a tree.
@@ -28,6 +29,7 @@ module Calabash
       true
     end
 
+    # Clear the console.
     def clear
       ConsoleHelpers.clear
       true
@@ -86,11 +88,12 @@ module Calabash
     # !@visibility private
     def puts_console_details
       puts ''
-      puts Color.blue('#             =>  Useful functions.  <=             #')
+      puts Color.blue('#             =>  Useful Methods  <=              #')
       puts Color.cyan('>     ids => List all the visible ids.')
       puts Color.cyan('> classes => List all the visible classes.')
       puts Color.cyan(">    tree => The app's visible view hierarchy.")
       puts Color.cyan('>    copy => Copy console commands to the Clipboard.')
+      puts Color.cyan('>   clear => Clear the console.')
       puts Color.cyan('> verbose => Turn debug logging on.')
       puts Color.cyan('>   quiet => Turn debug logging off.')
       puts ''

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -33,6 +33,34 @@ module Calabash
       true
     end
 
+    # Puts a message of the day.
+    def message_of_the_day
+      messages = [
+            "Let's get this done!",
+            'Ready to rumble.',
+            'Enjoy.',
+            'Remember to breathe.',
+            'Take a deep breath.',
+            "Isn't it time for a break?",
+            'Can I get you a coffee?',
+            'What is a calabash anyway?',
+            'Smile! You are on camera!',
+            'Let op! Wild Rooster!',
+            "Don't touch that button!",
+            "I'm gonna take this to 11.",
+            'Console. Engaged.',
+            'Your wish is my command.',
+            'This console session was created just for you.',
+            'Den som jager to harer, får ingen.',
+            'Uti, non abuti.',
+            'Non Satis Scire',
+            'Nullius in verba',
+            'Det ka æn jå væer ei jált'
+      ]
+
+      puts Color.green("Calabash #{Calabash::VERSION} says: '#{messages.shuffle.first}'")
+    end
+
     # !@visibility private
     def self.save_old_readline_history
       file_name = IRB.conf[:HISTORY_FILE]

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -61,6 +61,28 @@ module Calabash
       puts Color.green("Calabash #{Calabash::VERSION} says: '#{messages.shuffle.first}'")
     end
 
+    # Turn on debug logging.
+    def verbose
+      if Calabash::Environment.const_defined?('DEBUG')
+        Calabash::Environment.send(:remove_const, 'DEBUG')
+      end
+
+      Calabash::Environment.const_set('DEBUG', '1')
+      puts Color.blue('Turned on debug logging.')
+      true
+    end
+
+    # Turn off debug logging.
+    def quiet
+      if Calabash::Environment.const_defined?('DEBUG')
+        Calabash::Environment.send(:remove_const, 'DEBUG')
+      end
+
+      Calabash::Environment.const_set('DEBUG', '0')
+      puts Color.blue('Turned off debug logging.')
+      true
+    end
+
     # !@visibility private
     def puts_console_details
       puts ''

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -1,13 +1,17 @@
 require 'clipboard'
 
 module Calabash
+
+  # Helper methods for the Calabash console.
   module ConsoleHelpers
-    # Outputs all visible elements as a tree
+
+    # Outputs all visible elements as a tree.
     def tree
       ConsoleHelpers.dump(Device.default.dump)
       true
     end
 
+    # !@visibility private
     def self.save_old_readline_history
       file_name = IRB.conf[:HISTORY_FILE]
 
@@ -16,18 +20,23 @@ module Calabash
       end
     end
 
+    # !@visibility private
     def self.extended(base)
       save_old_readline_history
     end
 
+    # List the visible element classes.
     def classes
       query("*").map{|e| e['class']}.uniq
     end
 
+    # List the visible element ids.
     def ids
       query("*").map{|e| e['id']}.compact
     end
 
+    # Copy all the commands entered in the current console session into the OS
+    # Clipboard.
     def copy
       ConsoleHelpers.copy
       true
@@ -38,12 +47,14 @@ module Calabash
       true
     end
 
+    # !@visibility private
     def self.copy
       commands = filter_commands(current_console_history)
       string = commands.join($INPUT_RECORD_SEPARATOR)
       Clipboard.copy(string)
     end
 
+    # !@visibility private
     def self.clear
       if Gem.win_platform?
         system('cls')
@@ -54,6 +65,7 @@ module Calabash
       @@start_readline_history = readline_history
     end
 
+    # !@visibility private
     def self.current_console_history
       length = readline_history.length - @@start_readline_history.length
 
@@ -69,18 +81,22 @@ module Calabash
                                 /\s*clear_app(\(|\z)/,
                                 /\s*stop_app(\(|\z)/)
 
+    # !@visibility private
     def self.filter_commands(commands)
       commands.reject {|command| command =~ FILTER_REGEX}
     end
 
+    # !@visibility private
     def self.readline_history
       Readline::HISTORY.to_a
     end
 
+    # !@visibility private
     def self.dump(json_data)
       json_data['children'].each {|child| write_child(child)}
     end
 
+    # !@visibility private
     def self.write_child(data, indentation=0)
       render(data, indentation)
 
@@ -89,15 +105,18 @@ module Calabash
       end
     end
 
+    # !@visibility private
     def self.render(data, indentation)
       raise AbstractMethodError
     end
 
+    # !@visibility private
     def self.output(string, indentation)
       (indentation*2).times {print " "}
       print "#{string}"
     end
 
+    # !@visibility private
     def self.visible?(data)
       raise AbstractMethodError
     end

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -40,7 +40,12 @@ begin
 
     Calabash::IOS.setup_defaults!
 
-    Calabash.new_embed_method!(lambda {|*_| Calabash::Logger.info 'Embed is not available in the console.'})
+    embed_lambda = lambda do |*_|
+      Calabash::Logger.info 'Embed is not available in the console.'
+    end
+
+    Calabash.new_embed_method!(embed_lambda)
+
     Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
     message_of_the_day

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -11,11 +11,6 @@ ARGV.concat [ '--readline',
 begin
   require 'pry'
   Pry.config.history.file = '.pry_history'
-rescue LoadError => _
-
-end
-
-begin
   require 'pry-nav'
 rescue LoadError => _
 

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -22,48 +22,47 @@ rescue LoadError => _
 end
 
 begin
+  require 'awesome_print'
+  AwesomePrint.irb!
+rescue LoadError => e
+  msg = ["Caught a LoadError: could not load 'awesome_print'",
+         "#{e}",
+         '',
+         'Use bundler (recommended) or uninstall awesome_print.',
+         '',
+         '# Use bundler (recommended)',
+         '$ bundle update',
+         '$ bundle exec calabash console [path to apk]',
+         '',
+         '# Uninstall',
+         '$ gem update --system',
+         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+  puts msg
+  exit(1)
+end
 
-    begin
-        require 'awesome_print'
-    rescue LoadError => e
-        msg = ["Caught a LoadError: could not load 'awesome_print'",
-             "#{e}",
-             '',
-             'Use bundler (recommended) or uninstall awesome_print.',
-             '',
-             '# Use bundler (recommended)',
-             '$ bundle update',
-             '$ bundle exec calabash console [path to apk]',
-             '',
-             '# Uninstall',
-             '$ gem update --system',
-             '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
-        puts msg
-        exit(1)
-    end
+begin
 
-    AwesomePrint.irb!
+  require 'calabash/ios'
 
-    require 'calabash/ios'
+  extend Calabash::IOS
+  extend Calabash::ConsoleHelpers
 
-    extend Calabash::IOS
-    extend Calabash::ConsoleHelpers
+  Calabash::IOS.setup_defaults!
 
-    Calabash::IOS.setup_defaults!
+  embed_lambda = lambda do |*_|
+    Calabash::Logger.info 'Embed is not available in the console.'
+    true
+  end
 
-    embed_lambda = lambda do |*_|
-      Calabash::Logger.info 'Embed is not available in the console.'
-      true
-    end
+  Calabash.new_embed_method!(embed_lambda)
 
-    Calabash.new_embed_method!(embed_lambda)
+  Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
-    Calabash::Screenshot.screenshot_directory_prefix = 'console_'
-
-    message_of_the_day
+  message_of_the_day
 rescue Exception => e
-    puts 'Unable to start console:'
-    puts "#{e.class}: #{e.message}"
-    puts "#{e.backtrace.join("\n")}"
-    exit(1)
+  puts 'Unable to start console:'
+  puts "#{e.class}: #{e.message}"
+  puts "#{e.backtrace.join("\n")}"
+  exit(1)
 end

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -1,6 +1,14 @@
+require 'irb/completion'
+require 'irb/ext/save-history'
+
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = '.irb-history'
+
+ARGV.concat [ '--readline',
+              '--prompt-mode',
+              'simple']
+
 begin
-    require 'irb/completion'
-    require 'irb/ext/save-history'
 
     begin
         require 'awesome_print'
@@ -22,16 +30,6 @@ begin
     end
 
     AwesomePrint.irb!
-
-    ARGV.concat [ '--readline',
-                  '--prompt-mode',
-                  'simple']
-
-    # 50 entries in the list
-    IRB.conf[:SAVE_HISTORY] = 50
-
-    # Store results in home directory with specified file name
-    IRB.conf[:HISTORY_FILE] = '.irb-history'
 
     require 'calabash/ios'
 

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -54,6 +54,7 @@ begin
 
   Calabash::Screenshot.screenshot_directory_prefix = 'console_'
 
+  puts_console_details
   message_of_the_day
 rescue Exception => e
   puts 'Unable to start console:'

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -42,6 +42,8 @@ begin
 
     Calabash.new_embed_method!(lambda {|*_| Calabash::Logger.info 'Embed is not available in the console.'})
     Calabash::Screenshot.screenshot_directory_prefix = 'console_'
+
+    message_of_the_day
 rescue Exception => e
     puts 'Unable to start console:'
     puts "#{e.class}: #{e.message}"

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -9,6 +9,19 @@ ARGV.concat [ '--readline',
               'simple']
 
 begin
+  require 'pry'
+  Pry.config.history.file = '.pry_history'
+rescue LoadError => _
+
+end
+
+begin
+  require 'pry-nav'
+rescue LoadError => _
+
+end
+
+begin
 
     begin
         require 'awesome_print'

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -10,7 +10,7 @@ ARGV.concat [ '--readline',
 
 begin
   require 'pry'
-  Pry.config.history.file = '.pry_history'
+  Pry.config.history.file = '.pry-history'
   require 'pry-nav'
 rescue LoadError => _
 

--- a/lib/calabash/ios/lib/.irbrc
+++ b/lib/calabash/ios/lib/.irbrc
@@ -42,6 +42,7 @@ begin
 
     embed_lambda = lambda do |*_|
       Calabash::Logger.info 'Embed is not available in the console.'
+      true
     end
 
     Calabash.new_embed_method!(embed_lambda)


### PR DESCRIPTION
### Motivation

* Try to load pry and pry-nav.
* Add .pry-history so pry doesn't clobber the .irb history.
* Set .pry-history and load pry-nav in cucumber/ projects.
* Display information about help console methods.
* Display a message of the day with the version of Calabash.
* Add verbose and quiet methods to control debug logging.

@TobiasRoikjer 

1. I really need pry in the console.
2. I want to at least print the version of Calabash.

With those two changes, I can almost feel comfortable using the default .irbrc.

### TODO

- [ ] Display the app lifecyle methods?
- [ ] Change the prompt to just ">"?
- [x] Implement clear?  I don't want to clear by default because sometimes you want to refer back to things in the Terminal outside of the console.

### Notes

We don't have much debug logging do we?

```
$ be calabash console CalSmoke-cal.app
Running irb...

#             =>  Useful functions.  <=             #
>     ids => List all the visible ids.
> classes => List all the visible classes.
>    tree => The app's visible view hierarchy.
>    copy => Copy console commands to the Clipboard.
> verbose => Turn debug logging on.
>   quiet => Turn debug logging off.

Calabash 1.9.9.pre1 says: 'What is a calabash anyway?'
>
```

===

![image](https://cloud.githubusercontent.com/assets/466104/8993675/aca23728-3706-11e5-8639-579940407426.png)
