### PR TITLE
Wordpress: update the gemfile and docs

### DIFF
--- a/samples/wordpress/Gemfile
+++ b/samples/wordpress/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'calabash', :path => '../../'
+gem 'calabash', '1.9.9.pre2'
 gem 'cucumber'

--- a/samples/wordpress/Gemfile.lock
+++ b/samples/wordpress/Gemfile.lock
@@ -1,6 +1,9 @@
-PATH
-  remote: ../../
+GEM
+  remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.1)
+    awesome_print (1.6.1)
+    builder (3.2.2)
     calabash (1.9.9.pre2)
       awesome_print
       bundler (>= 1.3.0, < 2.0)
@@ -13,13 +16,6 @@ PATH
       luffa
       rubyzip (~> 1.1)
       run_loop (>= 1.3.3, < 2.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    CFPropertyList (2.3.1)
-    awesome_print (1.6.1)
-    builder (3.2.2)
     clipboard (1.0.6)
     cucumber (2.0.2)
       builder (>= 2.1.2)
@@ -31,7 +27,7 @@ GEM
     cucumber-core (1.2.0)
       gherkin (~> 2.12.0)
     diff-lcs (1.2.5)
-    edn (1.0.8)
+    edn (1.1.0)
     escape (0.0.4)
     geocoder (1.2.9)
     gherkin (2.12.2)
@@ -59,5 +55,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  calabash!
+  calabash (= 1.9.9.pre2)
   cucumber

--- a/samples/wordpress/README.md
+++ b/samples/wordpress/README.md
@@ -10,7 +10,6 @@ as your computer.
 
 ```
 $ bundle
-$ bundle exec calabash resign features/prebuilt/wordpress_android.apk
 
 # Run the cucumbers.
 $ bundle exec calabash run features/prebuilt/wordpress_android.apk


### PR DESCRIPTION
### Motivation

We need to pin the version to 1.9.9.pre2 (or the most recent release).  Otherwise, we have to mention users must run:

* copy_repos.sh
* change_old_files.sh
* be rake android:build

README.md - There is no need to resign or build the apk; you can just `run`.  Hurray!  +1 @TobiasRoikjer 
