### PR TITLE
iOS Pan gesture part 3

### DIFF
--- a/cucumber/ios/features/backdoor.feature
+++ b/cucumber/ios/features/backdoor.feature
@@ -39,8 +39,8 @@ Feature:  Backdoors
   # - (NSString *) stringWithBOOL:(BOOL) argument
   # - (NSString *) stringWithNSUInteger:(NSUInteger) argument
 
-  Background: The app has launched
-    Given I see the first tab
+  Background: Navigate to the controls tab
+    Given I see the controls tab
 
   Scenario: Backdoor selector is unknown
     And I call backdoor with an unknown selector

--- a/cucumber/ios/features/keyboard/keyboard.feature
+++ b/cucumber/ios/features/keyboard/keyboard.feature
@@ -4,8 +4,8 @@ Feature: Keyboard
   As a developer and tester
   I want a Calabash Keyboard API
 
-  Background: I should see the first view
-    Given I see the first tab
+  Background: Navigate to the controls tab
+    Given I see the controls tab
 
   Scenario: I should be able to type something
     And I touch the text field

--- a/cucumber/ios/features/keyboard/keyboard_delete.feature
+++ b/cucumber/ios/features/keyboard/keyboard_delete.feature
@@ -6,8 +6,8 @@ Feature: keyboard delete
   As a developer and tester
   I want to be able to app the delete key
 
-  Background: I should see the first view
-    Given I see the first tab
+  Background: Navigate to the controls tab
+    Given I see the controls tab
 
   Scenario: Default keyboard
     And the default keyboard is showing

--- a/cucumber/ios/features/orientation.feature
+++ b/cucumber/ios/features/orientation.feature
@@ -16,7 +16,7 @@ Feature: Orientation and Rotation
     And I can rotate to portrait
 
   Scenario: View controller does not support rotation
-    Given I see the first tab
+    Given I see the controls tab
     And the view controller does not support rotation
     When I rotate left
     Then no rotation occurred

--- a/cucumber/ios/features/pan.feature
+++ b/cucumber/ios/features/pan.feature
@@ -4,16 +4,15 @@ Feature: Pan
   As a developer
   I want a Pan API
 
-Background: Navigate to the scrolls page
-  Given I see the scrolls tab
-
 Scenario: Left-to-right screen pan in portrait
+  Given I see the scrolls tab
   When I touch the table views row
   Then I see the table views page
   When I pan left on the screen
   Then I go back to the Scrolls page
 
 Scenario: Left-to-right screen pan in landscape
+  Given I see the scrolls tab
   And I rotate so the home button is on the right
   When I touch the collection views row
   Then I see the collection views page
@@ -21,9 +20,18 @@ Scenario: Left-to-right screen pan in landscape
   Then I go back to the Scrolls page
 
 Scenario: Panning on a scroll view
+  Given I see the scrolls tab
   When I touch the scroll views row
   Then I see the scroll views page
   When I pan to the cayenne box on the simulator
   Then I expect an error to be raised about dragInsideWithOptions
   But I can pan to the cayenne box on the device
 
+Scenario: Full-screen panning
+  Given I see the gestures tab
+  And I am on the panning gestures page
+  Then I can pan full-screen bottom to top
+  Then I can pan full-screen left to right
+  Then I can pan full-screen top to bottom
+  Then I can pan full-screen right to left
+  And I clear the pan touch points

--- a/cucumber/ios/features/step_definitions/pan_steps.rb
+++ b/cucumber/ios/features/step_definitions/pan_steps.rb
@@ -35,3 +35,52 @@ But(/^I can pan to the cayenne box on the device$/) do
     wait_for_view("view marked:'cayenne'")
   end
 end
+
+And(/^I am on the panning gestures page$/) do
+  wait_for_animations
+  tap("view marked:'panning row'")
+
+  query = "view marked:'panning page'"
+  wait_for_view(query)
+end
+
+And(/^I clear the pan touch points$/) do
+  wait_for_animations
+
+  query = "view marked:'panning page'"
+  wait_for_view(query)
+
+  query(query, :clearTouchPoints)
+end
+
+Then(/^I can pan full-screen bottom to top$/) do
+  wait_for_animations
+
+  pan_screen_up
+
+  wait_for_views("view marked:'begin'", "view marked:'end'")
+end
+
+And(/^I can pan full-screen top to bottom$/) do
+  wait_for_animations
+
+  pan_screen_down
+
+  wait_for_views("view marked:'begin'", "view marked:'end'")
+end
+
+Then(/^I can pan full-screen left to right$/) do
+  wait_for_animations
+
+  pan_screen_right
+
+  wait_for_views("view marked:'begin'", "view marked:'end'")
+end
+
+Then(/^I can pan full-screen right to left$/) do
+  wait_for_animations
+
+  pan_screen_left
+
+  wait_for_views("view marked:'begin'", "view marked:'end'")
+end

--- a/cucumber/ios/features/step_definitions/shared_steps.rb
+++ b/cucumber/ios/features/step_definitions/shared_steps.rb
@@ -1,14 +1,16 @@
-Given(/^I see the (first|scrolls|special|tapping) tab$/) do |tab|
+Given(/^I see the (controls|gestures|scrolls|special|tapping) tab$/) do |tab|
   wait_for_view('tabBarButton')
   case tab
-  when 'first'
+  when 'controls'
     index = 0
-  when 'scrolls'
+  when 'gestures'
     index = 1
-  when 'special'
+  when 'scrolls'
     index = 2
-  when 'tapping'
+  when 'special'
     index = 3
+  when 'tapping'
+    index = 4
   end
   tap("tabBarButton index:#{index}")
   expected_view = "#{tab} page"

--- a/cucumber/ios/features/step_definitions/uia_steps.rb
+++ b/cucumber/ios/features/step_definitions/uia_steps.rb
@@ -1,7 +1,7 @@
 
 Then(/^I use UIA to touch the text field$/) do
   wait_for_view("UITextField marked:'text'")
-  uia_with_main_window("elements()['first page'].textFields()['text'].tap()")
+  uia_with_main_window("elements()['controls page'].textFields()['text'].tap()")
 end
 
 Then(/^I use UIA to type "([^"]*)"$/) do |text|

--- a/cucumber/ios/features/uia.feature
+++ b/cucumber/ios/features/uia.feature
@@ -5,7 +5,7 @@ Feature: UIA Automation Javascript API
   I want to interact with the UIAutomation Javascript API
 
   Scenario: Tapping
-    Given I see the first tab
+    Given I see the controls tab
     Then I use UIA to touch the text field
     And I wait for the keyboard
     Then I use UIA to type "Hello"

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -29,6 +29,7 @@ module Calabash
     require 'calabash/ios/uia'
     require 'calabash/ios/scroll'
     require 'calabash/ios/runtime'
+    require 'calabash/ios/gestures'
 
     include Calabash::IOS::Conditions
     include Calabash::IOS::Orientation
@@ -37,6 +38,7 @@ module Calabash
     include Calabash::IOS::UIA
     include Calabash::IOS::Scroll
     include Calabash::IOS::Runtime
+    include Calabash::IOS::Gestures
 
   end
 end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -103,7 +103,11 @@ module Calabash
           if content_offset != '*****'
             # Panning on anything with a content offset is broken.
             should_raise = true
+          elsif view_to_pan['class'][/TableViewCell/, 0]
+            should_raise = true
           else
+            new_query = "#{query} parent UITableViewCell"
+            should_raise = !gesture_waiter.query(new_query).empty?
             # TODO: Identify other conditions
             # TODO: Can we detect UITableViewCells?
             # The gist is that if the view is a UIScrollView or in a UIScrollView

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -94,12 +94,11 @@ module Calabash
         gesture_waiter = _gesture_waiter
         view_to_pan = gesture_waiter.wait_for_view(query, options)
 
-        if Device.default.simulator?
-
+        # * will never match a UIScrollView or subclass.
+        if Device.default.simulator? && query.to_s != '*'
           should_raise = false
 
           content_offset = gesture_waiter.query(query, :contentOffset).first
-
           if content_offset != '*****'
             # Panning on anything with a content offset is broken.
             should_raise = true

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -88,7 +88,7 @@ module Calabash
         begin
           _expect_valid_duration(options)
         rescue ArgumentError => e
-          raise ArgumentError e
+          raise ArgumentError, e
         end
 
         gesture_waiter = _gesture_waiter

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -116,9 +116,20 @@ module Calabash
 
           if should_raise
             message = [
+                  '',
                   "Apple's public UIAutomation API `dragInsideWithOptions` is broken for iOS Simulators >= 7",
-                  'Try using the scroll_* methods or test on a device.'
-            ].join("\n")
+                  '',
+                  'If you are trying to swipe-to-delete on a simulator, it will only work on a device.',
+                  '',
+                  'If you are trying to manipulate a table, collection or scroll view, try using the Scroll API.',
+                  '  * scroll                    # Scroll in a direction.',
+                  '  * scroll_to_row             # Scroll to a row with row / section indexes.',
+                  '  * scroll_to_row_with_mark   # Scroll to table row with a mark.',
+                  '  * scroll_to_item            # Scroll to collection item with item / section indexes.',
+                  '  * scroll_to_item_with_mark  # Scroll to collection item with a mark.',
+                  '',
+                  'All gestures work on physical devices.'
+            ].map { |msg| Color.red(msg) }.join("\n")
             raise message
           end
         end

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -149,6 +149,12 @@ module Calabash
         Calabash::QueryResult.create([view_to_pan], query)
       end
 
+      def pan_screen(view_to_pan, from_offset, to_offset, options)
+        uia_serialize_and_call(:panOffset, from_offset, to_offset, options)
+
+        Calabash::QueryResult.create([view_to_pan], '*')
+      end
+
       private
 
       # @!visibility private

--- a/lib/calabash/ios/gestures.rb
+++ b/lib/calabash/ios/gestures.rb
@@ -1,0 +1,107 @@
+module Calabash
+  module IOS
+
+    # @!visibility private
+    module Gestures
+
+      # Concrete implementation of pan_screen_up gesture.
+      def _pan_screen_up(options={})
+
+        gesture_options = options.dup
+        gesture_options[:duration] ||= 0.5
+        gesture_options[:timeout] ||= Calabash::Gestures::DEFAULT_GESTURE_WAIT_TIMEOUT
+
+        points_from_top = pan_points_from_top
+        points_from_bottom = pan_points_from_bottom
+
+        top_view = query('*').first
+
+        height = top_view['frame']['height'].to_f
+        width = top_view['frame']['width'].to_f
+
+        start_y = height - points_from_bottom
+        end_y = points_from_top
+        x = width/2.0
+
+        from_offset = coordinate(x, start_y)
+        to_offset = coordinate(x, end_y)
+
+        Device.default.pan_screen(top_view, from_offset, to_offset, gesture_options)
+      end
+
+      # Concrete implementation of pan_screen_down gesture.
+      def _pan_screen_down(options={})
+
+        gesture_options = options.dup
+        gesture_options[:duration] ||= 0.5
+        gesture_options[:timeout] ||= Calabash::Gestures::DEFAULT_GESTURE_WAIT_TIMEOUT
+
+        points_from_top = pan_points_from_top
+        points_from_bottom = pan_points_from_bottom
+
+        top_view = query('*').first
+
+        height = top_view['frame']['height'].to_f
+        width = top_view['frame']['width'].to_f
+
+        start_y = points_from_top
+        end_y = height - points_from_bottom
+        x = width/2.0
+
+        from_offset = coordinate(x, start_y)
+        to_offset = coordinate(x, end_y)
+
+        Device.default.pan_screen(top_view, from_offset, to_offset, gesture_options)
+      end
+
+      private
+
+      # Number of points from the top to start a full-screen vertical pan.
+      def pan_points_from_top
+        # 20 pixels for status bar in portrait; status bar is usually missing
+        # in landscape @todo route for status bar height
+
+        # Swiping from top will pull down the notification center.
+        # Touching the status bar can cause table views to scroll to the top.
+        orientation = status_bar_orientation
+        if orientation == 'down' || orientation == 'up'
+          points_from_top = 20
+        else
+          points_from_top = 10
+        end
+
+        # Navigation bar will intercept touches.
+        result = query('UINavigationBar')
+        if !result.empty?
+          navbar = result.first
+          points_from_top = points_from_top + navbar['frame']['height'] + 10
+        end
+        points_from_top
+      end
+
+      # Number of points from the bottom to start a full-screen vertical pan.
+      def pan_points_from_bottom
+        # Dragging from the bottom will lift the transport controls.
+        points_from_bottom = 10
+
+        # Tab bar will intercept touches _and_ its hit box is larger than its
+        # visible rect!
+        result = query('UITabBar')
+        if !result.empty?
+          tabbar = result.first
+          points_from_bottom = points_from_bottom + tabbar['frame']['height']
+        end
+
+        # @todo toolbars might not be anchored to the bottom of the screen
+
+        # Toolbars will intercept touches.
+        result = query('UIToolBar')
+        if !result.empty?
+          toolbar = result.first
+          points_from_bottom = points_from_bottom + toolbar['frame']['height']
+        end
+        points_from_bottom
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

```
@pan
Feature: Pan
  In order to perform swipes
  As a developer
  I want a Pan API

Scenario: Left-to-right screen pan in portrait
  Given I see the scrolls tab
  When I touch the table views row
  Then I see the table views page
  When I pan left on the screen
  Then I go back to the Scrolls page

Scenario: Left-to-right screen pan in landscape
  Given I see the scrolls tab
  And I rotate so the home button is on the right
  When I touch the collection views row
  Then I see the collection views page
  When I pan left on the screen
  Then I go back to the Scrolls page

Scenario: Panning on a scroll view
  Given I see the scrolls tab
  When I touch the scroll views row
  Then I see the scroll views page
  When I pan to the cayenne box on the simulator
  Then I expect an error to be raised about dragInsideWithOptions
  But I can pan to the cayenne box on the device

Scenario: Full-screen panning
  Given I see the gestures tab
  And I am on the panning gestures page
  Then I can pan full-screen bottom to top
  Then I can pan full-screen left to right
  Then I can pan full-screen top to bottom
  Then I can pan full-screen right to left
  And I clear the pan touch points
```