### PR TITLE
Add ability to print all calabash methods using $CAL_DEBUG_CALLED_MET…

### DIFF
--- a/lib/calabash/environment.rb
+++ b/lib/calabash/environment.rb
@@ -30,6 +30,9 @@ module Calabash
     # Is Calabash running in debug mode. True if $CAL_DEBUG is '1'
     DEBUG = variable('CAL_DEBUG') == '1'
 
+    # Experimental! Print every method that is called in Calabash
+    DEBUG_CALLED_METHODS = variable('CAL_DEBUG_CALLED_METHODS') == '1'
+
     # The path of the default app under test. This value is used if no app is
     # given from the command line. e.g. $ calabash run.
     #

--- a/lib/calabash/environment.rb
+++ b/lib/calabash/environment.rb
@@ -30,6 +30,7 @@ module Calabash
     # Is Calabash running in debug mode. True if $CAL_DEBUG is '1'
     DEBUG = variable('CAL_DEBUG') == '1'
 
+    # @!visibility private
     # Experimental! Print every method that is called in Calabash
     DEBUG_CALLED_METHODS = variable('CAL_DEBUG_CALLED_METHODS') == '1'
 


### PR DESCRIPTION
Example
```shell
CAL_DEBUG_CALLED_METHODS=1 be cucumber -p android
Will print every Calabash method called!
Warning: This might slow down your test drastically
and is an experimental feature.
Calabash method called: setup_defaults!
Calabash method called: variable("RESET_BETWEEN")
Calabash method called: variable("RESET_METHOD")
Using the android profile...
Feature: Initial experience
  As a user I want a helpful and simple initial
  experience with the app. I should be able to get help
  and login to an existing WordPress site.

Calabash method called: ensure_app_installed(nil)
Calabash method called: clear_app_data(nil)
Calabash method called: start_app(nil, {})
  Scenario: Starting the application          # features/initial_experience.feature:6
    Given I have just started the application # features/step_definitions/initial_experience.rb:1
Calabash method called: page(LoginPage, nil, nil, nil)
Calabash method called: await({:message=>"Expected to arrive at login page"})
Calabash method called: wait_for_view("android.widget.TextView text:'Sign in'", {:message=>"Expected to arrive at login page"}, nil, nil)
    Then I should arrive at the login screen  # features/step_definitions/initial_experience.rb:5
Calabash method called: stop_app
```