### PR TITLE
Release 1.9.9.pre3

### DIFF
--- a/lib/calabash/version.rb
+++ b/lib/calabash/version.rb
@@ -1,5 +1,5 @@
 module Calabash
 
   # @!visibility private
-  VERSION = '1.9.9.pre2'
+  VERSION = '1.9.9.pre3'
 end

--- a/samples/wordpress/Gemfile
+++ b/samples/wordpress/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'calabash', '1.9.9.pre2'
+gem 'calabash', '1.9.9.pre3'
 gem 'cucumber'
 
 gem 'pry'

--- a/samples/wordpress/Gemfile.lock
+++ b/samples/wordpress/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     CFPropertyList (2.3.1)
     awesome_print (1.6.1)
     builder (3.2.2)
-    calabash (1.9.9.pre2)
+    calabash (1.9.9.pre3)
       awesome_print
       bundler (>= 1.3.0, < 2.0)
       clipboard
@@ -15,7 +15,7 @@ GEM
       json
       luffa
       rubyzip (~> 1.1)
-      run_loop (>= 1.3.3, < 2.0)
+      run_loop (>= 1.4.1, < 2.0)
     clipboard (1.0.6)
     coderay (1.1.0)
     cucumber (2.0.2)
@@ -64,7 +64,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  calabash (= 1.9.9.pre2)
+  calabash (= 1.9.9.pre3)
   cucumber
   pry
   pry-nav


### PR DESCRIPTION
### Motivation

Released off the develop branch - not a good practice, but we are in dev mode.

There is one failing/flickering Android test:

```cucumber
  Scenario: Adding a self-hosted site               # features/login.feature:6
    Given I am on the login screen                  # features/step_definitions/login_steps.rb:29
    Then I should be able to add a self-hosted site # features/step_definitions/login_steps.rb:34
      Failed to perform gesture. java.lang.SecurityException: Injecting to another application requires INJECT_EVENTS permission (RuntimeError)
      ./features/android/pages/login_page.rb:50:in `toggle_self_hosted_site'
      ./features/android/pages/login_page.rb:35:in `enable_self_hosted_site'
      ./features/step_definitions/login_steps.rb:35:in `/^I should be able to add a self\-hosted site$/'
      features/login.feature:8:in `Then I should be able to add a self-hosted site'
```