### PR TITLE
Gestures: change flick and pan defaults

### DIFF
--- a/cucumber/ios/features/pan.feature
+++ b/cucumber/ios/features/pan.feature
@@ -1,14 +1,14 @@
 @pan
 Feature: Pan
-  In order to perform swipes
+  In order to perform swipes and drags
   As a developer
   I want a Pan API
 
-Scenario: Left-to-right screen pan in portrait
+ Scenario: Left-to-right screen pan in portrait
   Given I see the scrolls tab
   When I touch the table views row
   Then I see the table views page
-  When I pan left on the screen
+  When I pan right on the screen (swipe to go back)
   Then I go back to the Scrolls page
 
 Scenario: Left-to-right screen pan in landscape
@@ -16,7 +16,7 @@ Scenario: Left-to-right screen pan in landscape
   And I rotate so the home button is on the right
   When I touch the collection views row
   Then I see the collection views page
-  When I pan left on the screen
+  When I pan right on the screen (swipe to go back)
   Then I go back to the Scrolls page
 
 Scenario: Panning on a scroll view

--- a/cucumber/ios/features/step_definitions/pan_steps.rb
+++ b/cucumber/ios/features/step_definitions/pan_steps.rb
@@ -1,8 +1,9 @@
 
-When(/^I pan left on the screen$/) do
-  to = percent(0, 50)
-  from = percent(75, 50)
-  pan('*', to, from)
+When(/^I pan right on the screen \(swipe to go back\)$/) do
+  wait_for_animations
+
+  pan_screen_right
+
   wait_for_animations
 end
 

--- a/lib/calabash/gestures.rb
+++ b/lib/calabash/gestures.rb
@@ -165,26 +165,26 @@ module Calabash
     # Performs a `pan` heading `left` on the (first) view that matches `query`.
     # @see pan
     def pan_left(query, options={})
-      pan(query, {x: 90, y: 50}, {x: 10, y: 50}, options)
+      pan(query, {x: 95, y: 50}, {x: 5, y: 50}, options)
     end
 
     # Performs a `pan` heading `right` on the (first) view that matches
     # `query`.
     # @see pan
     def pan_right(query, options={})
-      pan(query, {x: 10, y: 50}, {x: 90, y: 50}, options)
+      pan(query, {x: 5, y: 50}, {x: 95, y: 50}, options)
     end
 
     # Performs a `pan` heading `up` on the (first) view that matches `query`.
     # @see pan
     def pan_up(query, options={})
-      pan(query, {x: 50, y: 90}, {x: 50, y: 10}, options)
+      pan(query, {x: 50, y: 95}, {x: 50, y: 5}, options)
     end
 
     # Performs a `pan` heading `down` on the (first) view that matches `query`.
     # @see pan
     def pan_down(query, options={})
-      pan(query, {x: 50, y: 10}, {x: 50, y: 90}, options)
+      pan(query, {x: 50, y: 5}, {x: 50, y: 95}, options)
     end
 
     # Performs a `pan` heading `left` on the screen.

--- a/lib/calabash/gestures.rb
+++ b/lib/calabash/gestures.rb
@@ -251,26 +251,26 @@ module Calabash
     # Performs a `flick` heading `left` on the (first) view that matches `query`.
     # @see flick
     def flick_left(query, options={})
-      flick(query, {x: 90, y: 50}, {x: 10, y: 50}, options)
+      flick(query, {x: 95, y: 50}, {x: 5, y: 50}, options)
     end
 
     # Performs a `flick` heading `right` on the (first) view that matches
     # `query`.
     # @see flick
     def flick_right(query, options={})
-      flick(query, {x: 10, y: 50}, {x: 90, y: 50}, options)
+      flick(query, {x: 5, y: 50}, {x: 95, y: 50}, options)
     end
 
     # Performs a `flick` heading `up` on the (first) view that matches `query`.
     # @see flick
     def flick_up(query, options={})
-      flick(query, {x: 50, y: 90}, {x: 50, y: 10}, options)
+      flick(query, {x: 50, y: 95}, {x: 50, y: 5}, options)
     end
 
     # Performs a `flick` heading `down` on the (first) view that matches `query`.
     # @see flick
     def flick_down(query, options={})
-      flick(query, {x: 50, y: 10}, {x: 50, y: 90}, options)
+      flick(query, {x: 50, y: 5}, {x: 50, y: 95}, options)
     end
 
     # Performs a `flick` heading `left` on the screen.

--- a/spec/lib/gesture_spec.rb
+++ b/spec/lib/gesture_spec.rb
@@ -274,8 +274,8 @@ describe Calabash::Gestures do
   describe '#flick_left' do
     it 'should invoke #flick with the right coordinates' do
       query = "my query"
-      from = {x: 90, y: 50}
-      to = {x: 10, y: 50}
+      from = {x: 95, y: 50}
+      to = {x: 5, y: 50}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:flick).with(query, from, to, options)
@@ -286,8 +286,8 @@ describe Calabash::Gestures do
   describe '#flick_right' do
     it 'should invoke #flick with the right coordinates' do
       query = "my query"
-      from = {x: 10, y: 50}
-      to = {x: 90, y: 50}
+      from = {x: 5, y: 50}
+      to = {x: 95, y: 50}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:flick).with(query, from, to, options)
@@ -298,8 +298,8 @@ describe Calabash::Gestures do
   describe '#flick_up' do
     it 'should invoke #flick with the right coordinates' do
       query = "my query"
-      from = {x: 50, y: 90}
-      to = {x: 50, y: 10}
+      from = {x: 50, y: 95}
+      to = {x: 50, y: 5}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:flick).with(query, from, to, options)
@@ -310,8 +310,8 @@ describe Calabash::Gestures do
   describe '#flick_down' do
     it 'should invoke #flick with the right coordinates' do
       query = "my query"
-      from = {x: 50, y: 10}
-      to = {x: 50, y: 90}
+      from = {x: 50, y: 5}
+      to = {x: 50, y: 95}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:flick).with(query, from, to, options)

--- a/spec/lib/gesture_spec.rb
+++ b/spec/lib/gesture_spec.rb
@@ -157,8 +157,8 @@ describe Calabash::Gestures do
   describe '#pan_left' do
     it 'should invoke #pan with the right coordinates' do
       query = "my query"
-      from = {x: 90, y: 50}
-      to = {x: 10, y: 50}
+      from = {x: 95, y: 50}
+      to = {x: 5, y: 50}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:pan).with(query, from, to, options)
@@ -169,8 +169,8 @@ describe Calabash::Gestures do
   describe '#pan_right' do
     it 'should invoke #pan with the right coordinates' do
       query = "my query"
-      from = {x: 10, y: 50}
-      to = {x: 90, y: 50}
+      from = {x: 5, y: 50}
+      to = {x: 95, y: 50}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:pan).with(query, from, to, options)
@@ -181,8 +181,8 @@ describe Calabash::Gestures do
   describe '#pan_up' do
     it 'should invoke #pan with the right coordinates' do
       query = "my query"
-      from = {x: 50, y: 90}
-      to = {x: 50, y: 10}
+      from = {x: 50, y: 95}
+      to = {x: 50, y: 5}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:pan).with(query, from, to, options)
@@ -193,8 +193,8 @@ describe Calabash::Gestures do
   describe '#pan_down' do
     it 'should invoke #pan with the right coordinates' do
       query = "my query"
-      from = {x: 50, y: 10}
-      to = {x: 50, y: 90}
+      from = {x: 50, y: 5}
+      to = {x: 50, y: 95}
       options = {my: :arg}
 
       expect(dummy_instance).to receive(:pan).with(query, from, to, options)


### PR DESCRIPTION
### Motivation

The most common iOS pan_screen_right gesture is the _swipe to go back_ gesture on UINavigationControllers.

The default 10/90 percents do not work for this gesture, but 5/95 do.

The same is true for flick.

@TobiasRoikjer Is this an acceptable compromise?   If not, can you suggest another way of handling the defaults for flick and pan?

```cucumber
 Scenario: Left-to-right screen pan in portrait
  Given I see the scrolls tab
  When I touch the table views row
  And I pan right on the screen (swipe to go back)
  Then I go back to the Scrolls page

Scenario: Left-to-right screen pan in landscape
  Given I see the scrolls tab
  And I rotate so the home button is on the right
  When I touch the collection views row
  And I pan right on the screen (swipe to go back)
  Then I go back to the Scrolls page
```