### PR TITLE
iOS: replace rotate(direction) with rotate_device_left and right_device_right

### DIFF
--- a/cucumber/ios/features/step_definitions/orientation_steps.rb
+++ b/cucumber/ios/features/step_definitions/orientation_steps.rb
@@ -26,7 +26,11 @@ end
 
 When(/^I rotate (left|right)$/) do |direction|
   @orientation_before_rotation = status_bar_orientation
-  rotate direction
+  if direction == 'left'
+    rotate_device_left
+  else
+    rotate_device_right
+  end
 end
 
 Then(/^no rotation occurred$/) do

--- a/lib/calabash/ios/device/rotation_mixin.rb
+++ b/lib/calabash/ios/device/rotation_mixin.rb
@@ -94,8 +94,10 @@ module Calabash
           playback_route(recording_name, form_factor)
 
           # Wait for rotation animation.
-          timeout = 1.0
-          condition_route('NONE_ANIMATING', timeout, '*')
+          #
+          # Can't wait for animations because there might be animations other
+          # than rotation on the screen.
+          sleep(0.4)
 
           orientation = status_bar_orientation
           if orientation == position

--- a/lib/calabash/ios/device/rotation_mixin.rb
+++ b/lib/calabash/ios/device/rotation_mixin.rb
@@ -59,10 +59,10 @@ module Calabash
       end
 
       # @!visibility private
-      # Caller must pass position one of these positions down, left, right, up
+      # Caller must pass position one of these positions :down, :left, :right, :up
       def rotate_home_button_to(position)
 
-        valid_positions = ['down', 'left', 'right', 'up']
+        valid_positions = [:down, :left, :right, :up]
         unless valid_positions.include?(position)
           raise ArgumentError,
                 "Expected '#{position}' to be on of #{valid_positions.join(', ')}"

--- a/lib/calabash/ios/orientation.rb
+++ b/lib/calabash/ios/orientation.rb
@@ -73,15 +73,15 @@ module Calabash
       # @return [String] The position of the home button relative to the status
       #  bar after the rotation. Can be one of 'down', 'left', 'right', 'up'.
       def rotate_home_button_to(position)
-        valid_positions = ['down', 'bottom', 'top', 'up', 'left', 'right']
-        unless valid_positions.include?(position)
+        valid_positions = [:down, :bottom, :top, :up, :left, :right]
+        unless valid_positions.include?(position.to_sym)
           raise ArgumentError,
                 "Expected '#{position}' to be one of #{valid_positions.join(', ')}"
         end
 
-        canonical_position = position
-        canonical_position = 'down' if position == 'bottom'
-        canonical_position = 'up' if position == 'top'
+        canonical_position = position.to_sym
+        canonical_position = :down if position.to_sym == :bottom
+        canonical_position = :up if position.to_sym == :top
 
         Calabash::Device.default.rotate_home_button_to(canonical_position)
       end

--- a/lib/calabash/ios/orientation.rb
+++ b/lib/calabash/ios/orientation.rb
@@ -4,7 +4,6 @@ module Calabash
     # On iOS, the presenting view controller must respond to rotation events.
     # If the presenting view controller does not respond to rotation events,
     # then no rotation will be performed.
-    # @!visibility private
     module Orientation
 
       # Returns the home button position relative to the status bar.
@@ -17,30 +16,31 @@ module Calabash
         Device.default.status_bar_orientation
       end
 
-      # Rotates the device in the direction indicated by `direction`.
-      #
-      # @example
-      #  > rotate('left')
-      #  > rotate('right')
+      # Rotate the device left - clockwise relative to the home button.
       #
       # @note
       #   The presenting view controller must respond to rotation events.
       #   If the presenting view controller does not respond to rotation events,
       #   then no rotation will be performed.
       #
-      # @param [String] direction The direction in which to rotate.
-      #  Valid arguments are :left and :right
-      #
-      # @raise [ArgumentError] If an invalid direction is given.
       # @return [String] The position of the home button relative to the status
       #  bar after the rotation. Can be one of 'down', 'left', 'right', 'up'.
-      def rotate(direction)
-        unless direction == 'left' || direction == 'right'
-          raise ArgumentError, "Expected '#{direction}' to be 'left' or 'right'"
-        end
+      def rotate_device_left
+        Device.default.rotate(:left)
+        status_bar_orientation
+      end
 
-        Device.default.rotate(direction.to_sym)
-        wait_for_animations
+      # Rotate the device right - counterclockwise relative to the home button.
+      #
+      # @note
+      #   The presenting view controller must respond to rotation events.
+      #   If the presenting view controller does not respond to rotation events,
+      #   then no rotation will be performed.
+      #
+      # @return [String] The position of the home button relative to the status
+      #  bar after the rotation. Can be one of 'down', 'left', 'right', 'up'.
+      def rotate_device_right
+        Device.default.rotate(:right)
         status_bar_orientation
       end
 

--- a/spec/lib/ios/orientation_spec.rb
+++ b/spec/lib/ios/orientation_spec.rb
@@ -136,13 +136,13 @@ describe Calabash::IOS::Orientation do
 
     describe 'canonical position' do
       it "converts 'bottom' to 'down'" do
-        expect(device).to receive(:rotate_home_button_to).with('down').and_return :orientation
+        expect(device).to receive(:rotate_home_button_to).with(:down).and_return :orientation
 
         expect(world.rotate_home_button_to('bottom')).to be == :orientation
       end
 
       it "converts 'top' to 'up'" do
-        expect(device).to receive(:rotate_home_button_to).with('up').and_return :orientation
+        expect(device).to receive(:rotate_home_button_to).with(:up).and_return :orientation
 
         expect(world.rotate_home_button_to('top')).to be == :orientation
       end

--- a/spec/lib/ios/orientation_spec.rb
+++ b/spec/lib/ios/orientation_spec.rb
@@ -115,28 +115,16 @@ describe Calabash::IOS::Orientation do
     end
   end
 
-  describe '#rotate' do
-    it 'raises error if invalid direction is passed' do
-      expect do
-        world.rotate 'invalid'
-      end.to raise_error ArgumentError
-    end
+  it '#rotate_device_right' do
+    expect(device).to receive(:rotate).with(:right).and_return true
+    expect(world).to receive(:status_bar_orientation).and_return :orientation
+    expect(world.rotate_device_right).to be == :orientation
+  end
 
-    it 'left' do
-      expect(device).to receive(:rotate).with(:left).and_return true
-      expect(world).to receive(:wait_for_animations)
-      expect(world).to receive(:status_bar_orientation).and_return :orientation
-
-      expect(world.rotate('left')).to be == :orientation
-    end
-
-    it 'right' do
-      expect(device).to receive(:rotate).with(:right).and_return true
-      expect(world).to receive(:wait_for_animations)
-      expect(world).to receive(:status_bar_orientation).and_return :orientation
-
-      expect(world.rotate('right')).to be == :orientation
-    end
+  it '#rotate_device_left' do
+    expect(device).to receive(:rotate).with(:left).and_return true
+    expect(world).to receive(:status_bar_orientation).and_return :orientation
+    expect(world.rotate_device_left).to be == :orientation
   end
 
   describe '#rotate_home_button_to' do


### PR DESCRIPTION
### Motivation

Differentiates between a rotate _gesture_ and rotating the device to change orientation.
