### PR TITLE
iOS Pinch gesture

### DIFF
--- a/cucumber/ios/features/pinch.feature
+++ b/cucumber/ios/features/pinch.feature
@@ -1,0 +1,32 @@
+@pinch
+Feature: Pinch
+In order to zoom in and out
+As a developer
+I want a Pinch API
+
+Scenario: Pinch in and out on a view
+  Given I see the gestures tab
+  And I see the pinching page
+  When I pinch out on the box, it gets bigger
+  When I pinch in on the box, it gets smaller
+  And I can zoom in on the box
+  And I can zoom out on the box
+
+Scenario: Zoom in and out on a map
+  Given I see the scrolls tab
+  And I see the map views page
+  Then I can zoom out on the map
+  And I can zoom in on the map
+
+Scenario: Zoom in and out on a map
+  Given I see the scrolls tab
+  And I see the map views page
+  Then I can zoom out on the screen
+  And I can zoom in on the screen
+
+Scenario: Pinch in and out on the screen
+  Given I see the scrolls tab
+  And I see the map views page
+  Then I can pinch in on the screen
+  And I can pinch out on the screen
+

--- a/cucumber/ios/features/step_definitions/pinch_steps.rb
+++ b/cucumber/ios/features/step_definitions/pinch_steps.rb
@@ -1,0 +1,145 @@
+
+And(/^I see the pinching page$/) do
+  query = "view marked:'pinching row'"
+
+  tap(query)
+
+  query = "view marked:'pinching page'"
+  wait_for_view(query)
+
+  wait_for_animations
+end
+
+When(/^I pinch out on the box, it gets bigger$/) do
+  query = "view marked:'box'"
+  box = wait_for_view(query)
+
+  original_height = box['rect']['height']
+  original_width = box['rect']['width']
+
+  pinch_out(query)
+
+  box = query(query).first
+  new_height = box['rect']['height']
+  new_width = box['rect']['width']
+
+  expect(new_height).to be > original_height
+  expect(new_width).to be > original_width
+end
+
+When(/^I pinch in on the box, it gets smaller$/) do
+  query = "view marked:'box'"
+  box = wait_for_view(query)
+
+  original_height = box['rect']['height']
+  original_width = box['rect']['width']
+
+  pinch_in(query)
+
+  box = query(query).first
+  new_height = box['rect']['height']
+  new_width = box['rect']['width']
+
+  expect(new_height).to be < original_height
+  expect(new_width).to be < original_width
+end
+
+And(/^I can zoom in on the box$/) do
+  query = "view marked:'box'"
+  box = wait_for_view(query)
+
+  original_height = box['rect']['height']
+  original_width = box['rect']['width']
+
+  pinch_to_zoom_in(query)
+
+  box = query(query).first
+  new_height = box['rect']['height']
+  new_width = box['rect']['width']
+
+  expect(new_height).to be > original_height
+  expect(new_width).to be > original_width
+end
+
+And(/^I can zoom out on the box$/) do
+  query = "view marked:'box'"
+  box = wait_for_view(query)
+
+  original_height = box['rect']['height']
+  original_width = box['rect']['width']
+
+  pinch_to_zoom_out(query)
+
+  box = query(query).first
+  new_height = box['rect']['height']
+  new_width = box['rect']['width']
+
+  expect(new_height).to be < original_height
+  expect(new_width).to be < original_width
+end
+
+And(/^I see the map views page$/) do
+  query = "view marked:'map views row'"
+
+  tap(query)
+
+  query = "view marked:'map'"
+  wait_for_view(query)
+
+  wait_for_animations
+end
+
+Then(/^I can zoom (out|in) on the map$/) do |in_out|
+  query = "view marked:'map'"
+
+  wait_for_view(query)
+
+  region = query(query, :region)
+
+  if in_out == 'out'
+    pinch_to_zoom_out(query)
+  else
+    pinch_to_zoom_in(query)
+  end
+
+  wait_for_animations
+  sleep 1.0
+  expect(query(query, :region)).not_to be == region
+end
+
+Then(/^I can zoom (out|in) on the screen$/) do |in_out|
+  query = "view marked:'map'"
+
+  wait_for_view(query)
+
+  region = query(query, :region)
+
+  if in_out == 'out'
+    pinch_screen_to_zoom_out
+  else
+    pinch_screen_to_zoom_in
+  end
+
+  wait_for_animations
+  sleep 1.0
+  expect(query(query, :region)).not_to be == region
+end
+
+Then(/^I can pinch (in|out) on the screen$/) do |in_out|
+  query = "view marked:'map'"
+
+  wait_for_view(query)
+
+  region = query(query, :region)
+
+  if in_out == 'out'
+    pinch_screen_out
+  else
+    pinch_screen_in
+  end
+
+  wait_for_animations
+  sleep 1.0
+  expect(query(query, :region)).not_to be == region
+end
+

--- a/lib/calabash/device.rb
+++ b/lib/calabash/device.rb
@@ -228,6 +228,7 @@ module Calabash
       end
 
       gesture_options = options.dup
+      gesture_options[:duration] ||= 0.5
       gesture_options[:timeout] ||= Calabash::Gestures::DEFAULT_GESTURE_WAIT_TIMEOUT
 
       _pinch(direction, query, gesture_options)

--- a/lib/calabash/gestures.rb
+++ b/lib/calabash/gestures.rb
@@ -323,42 +323,114 @@ module Calabash
       _flick_screen_down(options)
     end
 
-    # Performs a `pinch` outwards.
+    # Performs a **pinch** outwards on the first view match by `query`.
+    #
+    # @param [String, Hash, Calabash::Query] query A query describing the view
+    #   to pinch.
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_out(query, options={})
       Device.default.pinch(:out, query, options)
     end
 
-    # Performs a `pinch` inwards.
+    # Performs a **pinch** inwards on the first view match by `query`.
+    #
+    # @param [String, Hash, Calabash::Query] query A query describing the view
+    #   to pinch.
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_in(query, options={})
       Device.default.pinch(:in, query, options)
     end
 
-    # Performs a `pinch` outwards on the screen.
+    # Performs a **pinch** outwards on the screen.
+    #
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_screen_out(options={})
       _pinch_screen(:out, options)
     end
 
-    # Performs a `pinch` inwards on the screen.
+    # Performs a **pinch** inwards on the screen.
+    #
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_screen_in(options={})
       _pinch_screen(:in, options)
     end
 
-    # Performs a `pinch` to zoom out.
+    # Performs a **pinch** to zoom out.
+    #
+    # @param [String, Hash, Calabash::Query] query A query describing the view
+    #   to pinch.
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_to_zoom_out(query, options={})
       _pinch_to_zoom(:out, query, options)
     end
 
-    # Performs a `pinch` to zoom in.
+    # Performs a **pinch** to zoom in.
+    #
+    # @param [String, Hash, Calabash::Query] query A query describing the view
+    #   to pinch.
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_to_zoom_in(query, options={})
       _pinch_to_zoom(:in, query, options)
     end
 
-    # Performs a `pinch` to zoom in on the screen.
+    # Performs a **pinch** on the screen to zoom in.
+    #
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_screen_to_zoom_in(options={})
       _pinch_screen_to_zoom(:in, options)
     end
 
-    # Performs a `pinch` to zoom in on the screen.
+    # Performs a **pinch** on the screen to zoom out.
+    #
+    # @param [Hash] options Options for controlling the pinch.
+    # @option options [Numeric] :duration The duration of the pinch. On iOS,
+    #   the duration must be between 0.5 and 60.
+    #
+    # @raise [ViewNotFoundError] If the `query` returns no results.
+    # @raise [ArgumentError] If `query` is invalid.
+    # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_screen_to_zoom_out(options={})
       _pinch_screen_to_zoom(:out, options)
     end

--- a/lib/calabash/gestures.rb
+++ b/lib/calabash/gestures.rb
@@ -1,9 +1,13 @@
 module Calabash
-  # Methods for performing gestures.  Gestures are taps, flicks,
-  # and pans.
+  # Methods for performing gestures.  Gestures are taps, flicks, and pans.
   #
   # Many gestures take an optional :duration. On iOS, the duration must be
   # between 0.5 and 60 (seconds).  This is a limitation of the UIAutomation API.
+  #
+  # @note All gestures have _undefined return values._  This is intentional.
+  #  Please do not rely on return values of gestures in your tests.  For
+  #  convenience when working in the console, some gestures return sensible
+  #  values.  However, these values are subject to change.
   module Gestures
 
     # How long do we wait for a view to appear by default when performing a

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -274,6 +274,22 @@ module Calabash
         Calabash::QueryResult.create([view_to_pan], '*')
       end
 
+      # @!visibility private
+      def _pinch(direction, query, options={})
+        begin
+          _expect_valid_duration(options)
+        rescue ArgumentError => e
+          raise ArgumentError, e
+        end
+
+        view_to_pinch = _gesture_waiter.wait_for_view(query, options)
+        offset = uia_center_of_view(view_to_pinch)
+
+        uia_serialize_and_call(direction, offset, options)
+
+        Calabash::QueryResult.create([view_to_pinch], query)
+      end
+
       private
 
       # @!visibility private

--- a/lib/calabash/ios/device/gestures_mixin.rb
+++ b/lib/calabash/ios/device/gestures_mixin.rb
@@ -275,6 +275,9 @@ module Calabash
       end
 
       # @!visibility private
+      # @todo The pinch gestures are incredibly coarse grained.
+      #
+      # https://github.com/krukow/calabash-script/commit/fa33550ac7ac4f37da649498becef441d2284cd8
       def _pinch(direction, query, options={})
         begin
           _expect_valid_duration(options)
@@ -282,12 +285,26 @@ module Calabash
           raise ArgumentError, e
         end
 
-        view_to_pinch = _gesture_waiter.wait_for_view(query, options)
+        gesture_waiter = _gesture_waiter
+
+        view_to_pinch = gesture_waiter.wait_for_view(query, options)
         offset = uia_center_of_view(view_to_pinch)
 
-        uia_serialize_and_call(direction, offset, options)
+        gesture_direction = direction == :in ? :out : :in
 
-        Calabash::QueryResult.create([view_to_pinch], query)
+        uia_serialize_and_call(:pinchOffset, gesture_direction, offset, options)
+
+        after = gesture_waiter.query(query)
+        if after.empty?
+          after_result = nil
+        else
+          after_result = after.first
+        end
+
+        {
+              :before => Calabash::QueryResult.create([view_to_pinch], query),
+              :after => Calabash::QueryResult.create([after_result], query)
+        }
       end
 
       private

--- a/lib/calabash/ios/gestures.rb
+++ b/lib/calabash/ios/gestures.rb
@@ -108,6 +108,24 @@ module Calabash
         Device.default.flick_screen(top_view, from_offset, to_offset, gesture_options)
       end
 
+      # @!visibility private
+      # Concrete implementation of pinch_screen
+      def _pinch_screen(direction, options={})
+        Device.default.pinch(direction, '*', options)
+      end
+
+      # @!visibility private
+      # Concrete implementation of pinch_to_zoom
+      def _pinch_to_zoom(direction, query, options={})
+        Device.default.pinch(direction, query, options)
+      end
+
+      # @!visibility private
+      # Concrete implementation of pinch_screen_to_zoom
+      def _pinch_screen_to_zoom(direction, options={})
+        Device.default.pinch(direction, '*', options)
+      end
+
       private
 
       # Number of points from the top to start a full-screen vertical gesture.

--- a/lib/calabash/ios/gestures.rb
+++ b/lib/calabash/ios/gestures.rb
@@ -117,13 +117,15 @@ module Calabash
       # @!visibility private
       # Concrete implementation of pinch_to_zoom
       def _pinch_to_zoom(direction, query, options={})
-        Device.default.pinch(direction, query, options)
+        gesture_direction = direction == :in ? :out : :in
+        Device.default.pinch(gesture_direction, query, options)
       end
 
       # @!visibility private
       # Concrete implementation of pinch_screen_to_zoom
       def _pinch_screen_to_zoom(direction, options={})
-        Device.default.pinch(direction, '*', options)
+        gesture_direction = direction == :in ? :out : :in
+        Device.default.pinch(gesture_direction, '*', options)
       end
 
       private


### PR DESCRIPTION
### Motivation

```cucumber
Feature: Pinch
In order to zoom in and out
As a developer
I want a Pinch API

Scenario: Pinch in and out on a view
  Given I see the gestures tab
  And I see the pinching page
  When I pinch out on the box, it gets bigger
  When I pinch in on the box, it gets smaller
  And I can zoom in on the box
  And I can zoom out on the box

Scenario: Zoom in and out on a map
  Given I see the scrolls tab
  And I see the map views page
  Then I can zoom out on the map
  And I can zoom in on the map

Scenario: Zoom in and out on a map
  Given I see the scrolls tab
  And I see the map views page
  Then I can zoom out on the screen
  And I can zoom in on the screen

Scenario: Pinch in and out on the screen
  Given I see the scrolls tab
  And I see the map views page
  Then I can pinch in on the screen
  And I can pinch out on the screen
```