### PR TITLE
iOS: add API for setting the value of a UISlider

### DIFF
--- a/cucumber/ios/Gemfile.lock
+++ b/cucumber/ios/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    calabash (1.9.9.pre1)
+    calabash (1.9.9.pre3)
       awesome_print
       bundler (>= 1.3.0, < 2.0)
       clipboard
@@ -12,7 +12,7 @@ PATH
       json
       luffa
       rubyzip (~> 1.1)
-      run_loop (>= 1.3.3, < 2.0)
+      run_loop (>= 1.4.1, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -32,7 +32,7 @@ GEM
     cucumber-core (1.2.0)
       gherkin (~> 2.12.0)
     diff-lcs (1.2.5)
-    edn (1.0.8)
+    edn (1.1.0)
     escape (0.0.4)
     geocoder (1.2.9)
     gherkin (2.12.2)

--- a/cucumber/ios/config/cucumber.yml
+++ b/cucumber/ios/config/cucumber.yml
@@ -3,6 +3,12 @@
 APP = ENV['CAL_APP'] || File.expand_path("./CalSmoke-cal.app")
 IPA = ENV['CAL_APP'] || File.expand_path("./CalSmoke-cal.ipa")
 
+DEVICE="193688959205dc7eb48d603c558ede919ad8dd0d"
+ENDPOINT="http://denis.local:37265"
+
+SIX_PLUS="iPhone 6 Plus (8.4 Simulator)"
+IPAD_RETINA="iPad Retina (8.4 Simulator)"
+
 if ENV["USER"] == "jenkins"
   formatter = "progress"
 else
@@ -15,7 +21,7 @@ verbose: CAL_DEBUG=1
 formatter: -f <%= formatter %>
 
 # Launch on default simulator.
-default: CAL_APP=<%= APP %> -p formatter
+default: CAL_APP=<%= APP %> -p formatter CAL_DEVICE_ID="iPad Retina (8.4 Simulator)"
 
 # Launch on device.
-device:  CAL_APP=<%= IPA %> -p formatter
+device:  CAL_APP=<%= IPA %> CAL_DEVICE_ID=<%= DEVICE %> CAL_ENDPOINT=<%= ENDPOINT %>

--- a/cucumber/ios/features/slider.feature
+++ b/cucumber/ios/features/slider.feature
@@ -1,0 +1,10 @@
+@slider
+Feature: UISlider
+In order to interact with sliders
+As a developer
+I want a Slider API
+
+Scenario: Setting the value of a slider
+  Given I see the controls tab
+  Then I can get the min and max values of the slider
+  And I can set the value of the slider to 8

--- a/cucumber/ios/features/step_definitions/slider_steps.rb
+++ b/cucumber/ios/features/step_definitions/slider_steps.rb
@@ -1,0 +1,20 @@
+
+Then(/^I can get the min and max values of the slider$/) do
+  query = "UISlider marked:'slider'"
+  wait_for_view(query)
+
+  max = query(query, :maximumValue).first
+  min = query(query, :minimumValue).first
+
+  expect(max).to be == 10
+  expect(min).to be == -10
+end
+
+And(/^I can set the value of the slider to (\d+)$/) do |value|
+  query = "UISlider marked:'slider'"
+
+  slider_set_value(query, value.to_i)
+
+  value = query(query, :value).first
+  expect(value).to be == value.to_i
+end

--- a/lib/calabash/ios.rb
+++ b/lib/calabash/ios.rb
@@ -30,6 +30,7 @@ module Calabash
     require 'calabash/ios/scroll'
     require 'calabash/ios/runtime'
     require 'calabash/ios/gestures'
+    require 'calabash/ios/slider'
 
     include Calabash::IOS::Conditions
     include Calabash::IOS::Orientation
@@ -39,6 +40,7 @@ module Calabash
     include Calabash::IOS::Scroll
     include Calabash::IOS::Runtime
     include Calabash::IOS::Gestures
+    include Calabash::IOS::Slider
 
   end
 end

--- a/lib/calabash/ios/slider.rb
+++ b/lib/calabash/ios/slider.rb
@@ -1,0 +1,70 @@
+module Calabash
+  module IOS
+
+    # An interface for interacting with UISliders.
+    module Slider
+
+      # Sets the value of the first UISliders matched by `query` to `value`.
+      #
+      # If `query` matches a view that is not a UISlider or UISlider subclass,
+      # an error will be raised.
+      #
+      # An error will be raised if more than on view is matched by `query`.
+      #
+      # To avoid matching more than one UISlider (or subclass):
+      #  * Make the query more specific: "UISlider marked:'volume'"
+      #  * Use the index language feature:  "UISlider index:0"
+      #
+      # @example
+      #  slider_set_value("UISlider marked:'office slider'", 2)
+      #  slider_set_value("slider marked:'weather slider'", -1)
+      #  slider_set_value("UISlider", 11)
+      #
+      # @param [String, Hash, Calabash::Query] query A query to that indicates
+      #   in which slider to set the value.
+      # @param [Numeric] value The value to set the slider to.  value.to_s should
+      #  produce a String representation of a Number.
+      #
+      # @param [options] options Options to control the behavior of the gesture.
+      # @option options [Boolean] :animate (true) Animate the change.
+      # @option options [Boolean] :notify_targets (true) Simulate a UIEvent by
+      #  calling every target/action pair defined on the UISlider matching
+      #  `query`.
+      #
+      # @raise [RuntimeError] When `query` does not match exactly one slider.
+      # @raise [RuntimeError] When setting the value of the slider matched by
+      #  `query` is not successful.
+      def slider_set_value(query, value,  options={})
+        Query.ensure_valid_query(query)
+
+        default_options = {
+              :animate => true,
+              :notify_targets => true
+        }
+
+        merged_options = default_options.merge(options)
+
+        found_none = "Expected '#{query}' to match exactly one view, but found no matches."
+        query_object = Query.new(query)
+        wait_for(found_none) do
+          results = query(query_object)
+          if results.length > 1
+            message = [
+                  "Expected '#{query}' to match exactly one view, but found '#{results.length}'",
+                  results.join("\n")
+            ].join("\n")
+            fail(message)
+          else
+            results.length == 1
+          end
+        end
+
+        value_str = value.to_s
+
+        args = [merged_options[:animate], merged_options[:notify_targets]]
+
+        Device.default.map_route(query, :changeSlider, value_str, *args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

```
@slider
Feature: UISlider
In order to interact with sliders
As a developer
I want a Slider API

Scenario: Setting the value of a slider
  Given I see the controls tab
  Then I can get the min and max values of the slider
  And I can set the value of the slider to 8
```