### PR TITLE
Move flash to interactions

### DIFF
--- a/cucumber/ios/features/flash.feature
+++ b/cucumber/ios/features/flash.feature
@@ -1,0 +1,15 @@
+@flash
+Feature: Flash
+In order to explore my app's view heirarchy
+As an app tester and develop
+I want Calabash to be able to visually indicate which views match a query
+
+Background: Navigate to special tab
+ Given I see the special tab
+
+Scenario: Flashing
+  Then I can flash the buttons
+  And I can flash the labels in the tab bar
+  When the flash query matches no views
+  Then flash returns an empty array
+

--- a/cucumber/ios/features/step_definitions/flash_steps.rb
+++ b/cucumber/ios/features/step_definitions/flash_steps.rb
@@ -1,0 +1,18 @@
+
+Then(/^I can flash the buttons$/) do
+  views = flash('UIButton')
+  expect(views.length).to be == 2
+end
+
+And(/^I can flash the labels in the tab bar$/) do
+  views = flash("UITabBar descendant UITabBarButton descendant label")
+  expect(views.length).to be == 5
+end
+
+When(/^the flash query matches no views$/) do
+  @flash_results = flash("view marked:'some view that does not exist'")
+end
+
+Then(/^flash returns an empty array$/) do
+  expect(@flash_results.empty?).to be == true
+end

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -36,15 +36,6 @@ module Calabash
       true
     end
 
-    # Flashes any views matching `query`. Only one view is flashed at a time,
-    # in the order they are returned.
-    #
-    # @param [String, Hash, Calabash::Query] query The query to match the
-    #  view(s)
-    def flash(query)
-      Calabash::Device.default.map_route(Query.new(query), :flash)
-    end
-
     # Puts a message of the day.
     # @!visibility private
     def message_of_the_day

--- a/lib/calabash/interactions.rb
+++ b/lib/calabash/interactions.rb
@@ -60,6 +60,15 @@ module Calabash
       Calabash::Device.default.map_route(Query.new(query), :query, *args)
     end
 
+    # Flashes any views matching `query`. Only one view is flashed at a time,
+    # in the order they are returned.
+    #
+    # @param [String, Hash, Calabash::Query] query The query to match the
+    #  view(s)
+    def flash(query)
+      Calabash::Device.default.map_route(Query.new(query), :flash)
+    end
+
     # Evaluate javascript in a Web View. On iOS, an implicit return is
     # inserted, on Android an explicit return is needed.
     #

--- a/lib/calabash/ios/device/routes/handle_route_mixin.rb
+++ b/lib/calabash/ios/device/routes/handle_route_mixin.rb
@@ -9,7 +9,11 @@ module Calabash
 
         def route_post_request(request)
           begin
-            http_client.post(request)
+            if request.params[/\"method_name\":\"flash\"/, 0]
+              http_client.post(request, timeout: 30)
+            else
+              http_client.post(request)
+            end
           rescue => e
             raise Calabash::IOS::RouteError, e
           end


### PR DESCRIPTION
### Motivation

* Easier to test (discovered a bug in iOS implementation).
* Useful debugging tool - even in Scenarios.
* Potentially useful on the XTC with video capture.