### PR TITLE
iOS:  Runtime API

### DIFF
--- a/cucumber/ios/features/runtime.feature
+++ b/cucumber/ios/features/runtime.feature
@@ -1,0 +1,22 @@
+@runtime
+Feature:  Runtime Attributes
+In order to answer questions like: "Is this an iPhone 6+?"
+As a developer
+I want a Device Runtime API
+
+Scenario: The Runtime API
+  Given the app has launched
+  Then I can ask if the device is a simulator or physical device
+  And I can ask if the device is an iPad, iPhone, or iPod
+  And I can ask if the device is in the iPhone family
+  And I can ask if the app is an iPhone app emulated on an iPad
+  And I can ask if the device is a 4in device
+  And I can ask if the device is a 3.5in device
+  And I can ask if the device is an iPhone 6 or iPhone 6+
+  And I can ask for details about the device screen and app display details
+  And I can ask what version of iOS the device is running
+  And I can ask for the version of the Calabash iOS Server
+  And I can ask specific questions about the iOS version
+  And I can get version information about the app
+  And I can get a full dump of the runtime attributes
+

--- a/cucumber/ios/features/step_definitions/runtime_steps.rb
+++ b/cucumber/ios/features/step_definitions/runtime_steps.rb
@@ -1,0 +1,60 @@
+
+Then(/^I can ask if the device is a simulator or physical device$/) do
+  expect([simulator?, physical_device?].any?).to be == true
+end
+
+And(/^I can ask if the device is an iPad, iPhone, or iPod$/) do
+  expect([ipad?, iphone?, ipod?].any?).to be == true
+end
+
+And(/^I can ask if the device is in the iPhone family$/) do
+  device_family_iphone?
+end
+
+And(/^I can ask if the app is an iPhone app emulated on an iPad$/) do
+  iphone_app_emulated_on_ipad?
+end
+
+And(/^I can ask if the device is a (4in|3.5in) device$/) do |inches|
+  iphone_4in?
+  iphone_35in?
+end
+
+And(/^I can ask if the device is an iPhone 6 or iPhone 6\+$/) do
+  iphone_6?
+  iphone_6_plus?
+end
+
+And(/^I can ask for details about the device screen and app display details$/) do
+  hash = app_screen_details
+  expect(hash).to be_a_kind_of(Hash)
+  expect(hash[:sample]).to be_truthy
+  expect(hash[:scale]).to be_truthy
+  expect(hash[:height]).to be_truthy
+  expect(hash[:width]).to be_truthy
+end
+
+And(/^I can ask what version of iOS the device is running$/) do
+  expect(ios_version).to be_a_kind_of(RunLoop::Version)
+end
+
+And(/^I can ask for the version of the Calabash iOS Server$/) do
+  expect(server_version).to be_a_kind_of(RunLoop::Version)
+end
+
+And(/^I can ask specific questions about the iOS version$/) do
+  expect([ios6?, ios7?, ios8?, ios9?].any?).to be == true
+end
+
+And(/^I can get version information about the app$/) do
+  hash = app_version_details
+  expect(hash).to be_a_kind_of(Hash)
+  expect(hash[:bundle_version]).to be_truthy
+  expect(hash[:short_version]).to be_truthy
+end
+
+And(/^I can get a full dump of the runtime attributes$/) do
+  hash = runtime_details
+  expect(hash).to be_a_kind_of(Hash)
+end
+

--- a/lib/calabash/ios/device/device_implementation.rb
+++ b/lib/calabash/ios/device/device_implementation.rb
@@ -22,8 +22,6 @@ module Calabash
 
       include Calabash::IOS::GesturesMixin
 
-      # @todo Should these be public?
-      # @todo If public, document!
       attr_reader :run_loop
       attr_reader :uia_strategy
       attr_reader :start_options
@@ -290,6 +288,13 @@ module Calabash
         # app has launched.
         expect_runtime_attributes_available(__method__)
         runtime_attributes.server_version
+      end
+
+      # @!visibility private
+      # A dump of runtime details.
+      def runtime_details
+        expect_runtime_attributes_available(__method__)
+        @runtime_attributes.runtime_info
       end
 
       # Is this device a simulator?
@@ -729,11 +734,18 @@ module Calabash
 
       # @!visibility private
       def expect_runtime_attributes_available(method_name)
+
         if runtime_attributes.nil?
-          logger.log("The method '#{method_name}' is not available to IOS::Device until", :info)
-          logger.log('the app has been launched with Calabash start_app.', :info)
-          raise "The method '#{method_name}' can only be called after the app has been launched"
+          begin
+            # Populates the @runtime_attributes
+            wait_for_server_to_start({:timeout => 1.0})
+          rescue Calabash::Device::EnsureTestServerReadyTimeoutError => _
+            logger.log("The method '#{method_name}' is not available to IOS::Device until", :info)
+            logger.log('the app has been launched with Calabash start_app.', :info)
+            raise "The method '#{method_name}' can only be called after the app has been launched"
+          end
         end
+
         true
       end
 

--- a/lib/calabash/ios/device/runtime_attributes.rb
+++ b/lib/calabash/ios/device/runtime_attributes.rb
@@ -9,6 +9,10 @@ module Calabash
       require 'run_loop'
 
       # @!visibility private
+      # The hash passed to initialize.
+      attr_reader :runtime_info
+
+      # @!visibility private
       # Creates a new instance of DeviceRuntimeInfo.
       # @param [Hash] runtime_info The result of calling the version route on
       #  on the server
@@ -173,11 +177,6 @@ module Calabash
           runtime_info['system']
         end.call
       end
-
-      # @!visibility private
-      # The hash passed to initialize.
-      attr_reader :runtime_info
-
     end
   end
 end

--- a/lib/calabash/ios/runtime.rb
+++ b/lib/calabash/ios/runtime.rb
@@ -1,14 +1,159 @@
 module Calabash
   module IOS
+
+    # Methods that describe the runtime attributes of the device under test.
+    #
+    # @note The key/value pairs in the Hash returned by #runtime_details are
+    #  not stable and can change at any time.  Don't write tests that rely on
+    #  specific keys or values in this Hash.  Instead, use the API methods
+    #  defined in this class.
     module Runtime
 
-      # @todo Complete and document the Runtime API
+      # Is the device under test a simulator?
       def simulator?
         Calabash::IOS::Device.default.simulator?
       end
 
+      # Is the device under test a physical device?
       def physical_device?
         Calabash::IOS::Device.default.physical_device?
+      end
+
+      # Is the device under test an iPad?
+      def ipad?
+        Calabash::IOS::Device.default.device_family == 'iPad'
+      end
+
+      # Is the device under test an iPhone?
+      def iphone?
+        Calabash::IOS::Device.default.device_family == 'iPhone'
+      end
+
+      # Is the device under test an iPod?
+      def ipod?
+        Calabash::IOS::Device.default.device_family == 'iPod'
+      end
+
+      # Is the device under test an iPhone or iPod?
+      def device_family_iphone?
+        iphone? or ipod?
+      end
+
+      # Is the app that is being tested an iPhone app emulated on an iPad?
+      #
+      # An iPhone only app running on an iPad will be displayed in an emulated
+      # mode.  Starting in iOS 7, such apps will always be launched in 2x mode.
+      def iphone_app_emulated_on_ipad?
+        Calabash::IOS::Device.default.iphone_app_emulated_on_ipad?
+      end
+
+      # Is the device under test have a 4 inch screen?
+      def iphone_4in?
+        Calabash::IOS::Device.default.form_factor == 'iphone 4in'
+      end
+
+      # Is the device under test an iPhone 6.
+      def iphone_6?
+        Calabash::IOS::Device.default.form_factor == 'iphone 6'
+      end
+
+      # Is the device under test an iPhone 6+?
+      def iphone_6_plus?
+        Calabash::IOS::Device.default.form_factor == 'iphone 6 +'
+      end
+
+      # Is the device under test an iPhone 3.5in?
+      def iphone_35in?
+        Calabash::IOS::Device.default.form_factor == 'iphone 3.5in'
+      end
+
+      # The screen dimensions and details about scale and sample rates.
+      #
+      # @example
+      #  > app_screen_details
+      #  => {
+      #        :height => 1,
+      #        :height => 1334,
+      #        :width => 750,
+      #        :scale => 2
+      #      }
+      #
+      # @return [Hash] See the example.
+      def app_screen_details
+        Calabash::IOS::Device.default.screen_dimensions
+      end
+
+      # The version of iOS running on the test device.
+      #
+      # @example
+      #  > ios_version.major
+      #  > ios_version.minor
+      #  > ios_version.patch
+      #
+      # @return [RunLoop::Version] A version object.
+      def ios_version
+        Calabash::IOS::Device.default.ios_version
+      end
+
+      # Is the device under test running iOS 6?
+      def ios6?
+        ios_version.major == 6
+      end
+
+      # Is the device under test running iOS 7?
+      def ios7?
+        ios_version.major == 7
+      end
+
+      # Is the device under test running iOS 8?
+      def ios8?
+        ios_version.major == 8
+      end
+
+      # Is the device under test running iOS 9?
+      def ios9?
+        ios_version.major == 9
+      end
+
+      # The version of the Calabash iOS Server running in the app.
+      #
+      # @example
+      #  > server_version.major
+      #  > server_version.minor
+      #  > server_version.patch
+      #
+      # @return [RunLoop::Version] A version object.
+      def server_version
+        Calabash::IOS::Device.default.server_version
+      end
+
+      # Details about the version of the app under test.
+      #
+      # Will always contain these two keys:
+      #
+      #  * :bundle_version => CFBundleVersion
+      #  * :short_version => CFBundleShortVersionString
+      #
+      # It may contain other key/value pairs.
+      #
+      # @return [Hash] Key/value pairs that describe the version of the app
+      #  under test.
+      def app_version_details
+        hash = runtime_details
+        {
+              :bundle_version => hash['app_version'],
+              :short_version => hash['short_version_string']
+        }
+      end
+
+      # A hash of all the details about the runtime environment.
+      #
+      # @note The key/value pairs in this Hash are subject to change.  Don't
+      #  write tests that rely on a specific key appearing in the Hash.  Use
+      #  the methods in the {Calabash::IOS::Runtime} module instead.
+      # @return[Hash] Key/value pairs that describe the runtime environment.
+      def runtime_details
+        Calabash::IOS::Device.default.runtime_details
       end
     end
   end

--- a/spec/lib/ios/device/device_spec.rb
+++ b/spec/lib/ios/device/device_spec.rb
@@ -773,6 +773,8 @@ describe Calabash::IOS::Device do
 
     describe '#expect_runtime_attributes_available' do
       it 'raises an error when runtime_attributes are not available' do
+        error_class = Calabash::Device::EnsureTestServerReadyTimeoutError
+        expect(device).to receive(:ensure_test_server_ready).with({:timeout => 1}).and_raise error_class
         device.instance_variable_set(:@runtime_attributes, nil)
         expect {
           device.send(:expect_runtime_attributes_available, 'foo')


### PR DESCRIPTION
### Motivation

```
Scenario: The Runtime API
  Given the app has launched
  Then I can ask if the device is a simulator or physical device
  And I can ask if the device is an iPad, iPhone, or iPod
  And I can ask if the device is in the iPhone family
  And I can ask if the app is an iPhone app emulated on an iPad
  And I can ask if the device is a 4in device
  And I can ask if the device is a 3.5in device
  And I can ask if the device is an iPhone 6 or iPhone 6+
  And I can ask for details about the device screen and app display details
  And I can ask what version of iOS the device is running
  And I can ask for the version of the Calabash iOS Server
  And I can ask specific questions about the iOS version
  And I can get version information about the app
  And I can get a full dump of the runtime attributes
```