### PR TITLE
iOS: send app to background

### DIFF
--- a/cucumber/ios/config/cucumber.yml
+++ b/cucumber/ios/config/cucumber.yml
@@ -21,7 +21,12 @@ verbose: CAL_DEBUG=1
 formatter: -f <%= formatter %>
 
 # Launch on default simulator.
-default: CAL_APP=<%= APP %> -p formatter CAL_DEVICE_ID="iPad Retina (8.4 Simulator)"
+simulator_vars: CAL_APP=<%= APP %> #CAL_DEVICE_ID="iPad Retina (8.4 Simulator)"
+simulator_tags: --tags ~@device_only
+default:        -p simulator_vars -p simulator_tags -p formatter
 
 # Launch on device.
-device:  CAL_APP=<%= IPA %> CAL_DEVICE_ID=<%= DEVICE %> CAL_ENDPOINT=<%= ENDPOINT %>
+device_vars:  CAL_APP=<%= IPA %> CAL_DEVICE_ID=<%= DEVICE %> CAL_ENDPOINT=<%= ENDPOINT %>
+device_tags:  --tags ~@simulator_only
+device:       -p device_vars -p device_tags -p formatter
+

--- a/cucumber/ios/features/background.feature
+++ b/cucumber/ios/features/background.feature
@@ -1,0 +1,18 @@
+@background
+Feature: Send App to Background
+In order to test how my app behaves when it goes to the background
+As a developer
+I want a Background API
+
+Background: Launch the app
+  Given the app has launched
+
+Scenario: Simulate touching the home button
+  Then backgrounding the app for less than one second raises an error
+  And backgrounding the app for more than sixty seconds raises an error
+  But I can send the app to the background for 1 seconds
+
+@shared_element
+Scenario: Background does not work with :shared_element
+  Then backgrounding app when UIA strategy is :shared_element raises an error
+

--- a/cucumber/ios/features/background.feature
+++ b/cucumber/ios/features/background.feature
@@ -10,9 +10,18 @@ Background: Launch the app
 Scenario: Simulate touching the home button
   Then backgrounding the app for less than one second raises an error
   And backgrounding the app for more than sixty seconds raises an error
-  But I can send the app to the background for 1 seconds
+  But I can send the app to the background for 1 second
 
 @shared_element
-Scenario: Background does not work with :shared_element
-  Then backgrounding app when UIA strategy is :shared_element raises an error
+Scenario: Backgrounding works with :shared_element
+  Then I can background the app when UIA strategy is :shared_element
+
+@host
+Scenario: Backgrounding works with :host
+  Then I can background the app when UIA strategy is :host
+
+@preferences
+@simulator_only
+Scenario: Background works with :preferences
+  Then I can background the app when UIA strategy is :preferences
 

--- a/cucumber/ios/features/step_definitions/background_steps.rb
+++ b/cucumber/ios/features/step_definitions/background_steps.rb
@@ -14,3 +14,7 @@ end
 But(/^I can send the app to the background for (\d+) seconds?$/) do |seconds|
   send_app_to_background(seconds.to_i)
 end
+
+Then(/^I can background the app when UIA strategy is (?::host|:preferences|:shared_element)$/) do
+  send_app_to_background(1.0)
+end

--- a/cucumber/ios/features/step_definitions/background_steps.rb
+++ b/cucumber/ios/features/step_definitions/background_steps.rb
@@ -1,0 +1,16 @@
+
+Then(/^backgrounding the app for less than one second raises an error$/) do
+  expect do
+    send_app_to_background(0.5)
+  end.to raise_error ArgumentError, /must be between 1 and 60/
+end
+
+And(/^backgrounding the app for more than sixty seconds raises an error$/) do
+  expect do
+    send_app_to_background(61)
+  end.to raise_error ArgumentError, /must be between 1 and 60/
+end
+
+But(/^I can send the app to the background for (\d+) seconds?$/) do |seconds|
+  send_app_to_background(seconds.to_i)
+end

--- a/cucumber/ios/features/support/hooks.rb
+++ b/cucumber/ios/features/support/hooks.rb
@@ -1,5 +1,17 @@
 require 'calabash'
 
+Before('@shared_element') do
+  @uia_strategy = :shared_element
+end
+
+Before('@host') do
+  @uia_strategy = :shared_element
+end
+
+Before('@preferences') do
+  @uia_strategy = :preferences
+end
+
 Before do |scenario|
   if scenario.respond_to?(:scenario_outline)
     scenario = scenario.scenario_outline
@@ -8,11 +20,17 @@ Before do |scenario|
   AppLifeCycle.on_new_scenario(scenario)
   Cucumber.wants_to_quit = false
 
-  start_app
+  if @uia_strategy
+    options = {:uia_strategy => @uia_strategy}
+  else
+    options = {}
+  end
+
+  start_app(options)
 end
 
 After do
-  #stop_app
+  @uia_strategy = nil
 end
 
 module AppLifeCycle

--- a/lib/calabash/android/interactions.rb
+++ b/lib/calabash/android/interactions.rb
@@ -3,6 +3,8 @@ require 'time'
 
 module Calabash
   module Android
+
+    # Interactions with your app that are specific to Android.
     module Interactions
       # Go back. If the keyboard is shown, it will be dismissed.
       def go_back

--- a/lib/calabash/ios/interactions.rb
+++ b/lib/calabash/ios/interactions.rb
@@ -1,7 +1,35 @@
 module Calabash
   module IOS
-    # @!visibility private
+
+    # Interactions with your app that are specific to iOS
     module Interactions
+
+      # Sends app to background. Simulates pressing the home button.
+      #
+      # @note Cannot be more than 60 seconds.
+      #
+      # @param [Numeric] seconds The number of seconds to keep the app
+      #   in the background
+      # @raise [ArgumentError] If number of seconds is less than 1 and more
+      #   than 60 seconds.
+      def send_app_to_background(seconds)
+        unless (1..60).member?(seconds)
+          raise ArgumentError,
+            "Number of seconds: '#{seconds}' must be between 1 and 60"
+        end
+
+        javascript = %Q(
+          var x = target.deactivateAppForDuration(#{seconds});
+          var MAX_RETRY=5, retry_count = 0;
+          while (!x && retry_count < MAX_RETRY) {
+            x = target.deactivateAppForDuration(#{seconds});
+            retry_count += 1
+          };
+          x
+        )
+        uia(javascript)
+      end
+
       # @!visibility private
       def _evaluate_javascript_in(query, javascript)
         query(query, calabashStringByEvaluatingJavaScript: javascript)


### PR DESCRIPTION
### Motivation

```
Scenario: Simulate touching the home button
  Then backgrounding the app for less than one second raises an error
  And backgrounding the app for more than sixty seconds raises an error
  But I can send the app to the background for 1 second

@shared_element
Scenario: Backgrounding works with :shared_element
  Then I can background the app when UIA strategy is :shared_element

@host
Scenario: Backgrounding works with :host
  Then I can background the app when UIA strategy is :host

@preferences
@simulator_only
Scenario: Background works with :preferences
  Then I can background the app when UIA strategy is :preferences
```