### PR TITLE
iOS: at launch, ensure iPhone apps emulated on iPad are in 1X zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ $ rake -T
 rake android:build     # Build the Android test server
 rake build             # Build calabash-1.9.9.pre2.gem into the pkg directory
 rake ctags             # Generate ctags in ./git/tags
-rake cucumber:android  # Run Android cucumber tests
-rake cucumber:ios      # Run iOS cucumber tests
 rake install           # Build and install calabash-1.9.9.pre2.gem into system gems
 rake release           # Create tag v1.9.9.pre2 and build and push calabash-1.9.9.pre2.gem to Rubygems
 rake spec              # Run RSpec code examples

--- a/README.md
+++ b/README.md
@@ -61,28 +61,5 @@ $ be cucumber
 
 ### Cucumber iOS
 
-```
-$ cd cucumber/ios
-$ bundle update
-$ rake ensure_app  # Optional. See note below.
-$ be cucumber
-```
-
-The rake task `ensure_app` checks the `cucumber/ios` directory for
-CalSmoke-cal.app. If it exists, it will do nothing.  If it does not exist,
-it will pull the latest sources from the CalSmoke repo, build the
-CalSmoke-cal.app from the master branch, and install it in the
-`cucumber/ios` directory.
-
-If you want to use a different CalSmoke-cal.app, drop it into `cucumber/ios`
-or call cucumber with `CAL\_APP` set.
-
-```
-$ CAL_APP=/path/to/your/CalSmoke-cal.app be cucumber
-```
-
-The rake task `ensure_ipa` does the same thing, but for the CalSmoke-cal.ipa.
-
-Testing against physical devices requires that you have ideviceinstaller
-installed in /usr/local/bin/ideviceinstaller.
+See `cucumber/ios/README.md`.
 

--- a/Rakefile
+++ b/Rakefile
@@ -63,22 +63,6 @@ task :ctags do
   sh cmd
 end
 
-namespace :cucumber do
-  desc 'Run iOS cucumber tests.'
-  task :ios do
-    Dir.chdir('cucumber/ios/') do
-      sh 'bundle exec cucumber'
-    end
-  end
-
-  desc 'Run Android cucumber tests.'
-  task :android do
-    Dir.chdir('cucumber/android') do
-      sh 'bundle exec cucumber'
-    end
-  end
-end
-
 namespace :android do
   task :ensure_files_exist do
     Calabash::Build::AndroidTestServer.ensure_test_server_exists
@@ -99,3 +83,4 @@ namespace :android do
   task :build => [:ensure_files_exist, :build_test_server] do
   end
 end
+

--- a/cucumber/ios/Gemfile
+++ b/cucumber/ios/Gemfile
@@ -17,3 +17,7 @@ gem 'pry-nav'
 
 # Makes tidy Xcode build logs.
 gem 'xcpretty'
+
+# CI and workflow tool
+gem 'luffa'
+

--- a/cucumber/ios/Gemfile.lock
+++ b/cucumber/ios/Gemfile.lock
@@ -88,6 +88,7 @@ DEPENDENCIES
   calabash!
   chronic (>= 0.10, < 1.0)
   cucumber (~> 2.0)
+  luffa
   pry
   pry-nav
   rspec (~> 3.0)

--- a/cucumber/ios/README.md
+++ b/cucumber/ios/README.md
@@ -2,27 +2,44 @@
 
 Features that demonstrate and test Calabash on iOS.
 
-### Preparing
-
-To avoid checking apps and ipas into git, you must build the
-apps from source.
-
 **TODO** It would be nice to have a public build server.
 
-Use the following rake tasks to build and install the apps and ipas
-required for testing.
+### Preparing
+
+You must build the apps from sources.
 
 ```
 $ cd cucumber/ios
 $ bundle
-$ be rake ensure_apps
-$ be rake ensure_ipas # Only if you need to test on physical devices.
+$ be rake install_apps
 ```
 
 You only need to run these rake tasks once.
 
 If you want to use different binaries, drop them into
 `cucumber/ios/binaries`.
+
+To ensure you have the most recent sources for the apps:
+
+```
+$ be rake clean
+```
+
+#### Testing on Physical Devices
+
+Testing against physical devices requires that you have ideviceinstaller
+installed.
+
+```
+$ be rake install_ipas
+```
+
+If you have multiple Developer accounts, you might need to set the
+`CODE_SIGN_IDENTITY` variable when you are building the ipas.
+
+```
+$ CODE_SIGN_IDENTITY="iPhone Developer: Joshua Moody (8QXXXXX9F)" be rake ensure_ipas
+```
 
 ### Testing
 
@@ -32,9 +49,8 @@ The Gemfile pins the calabash gem to `:path => '../../'`.
 
 ```
 $ bundle
-$ be cucumber
+$ be cucumber             # Against the default simulator
+$ be cucumber -p device   # Against a device.  See ./config/cucumber.yml
 ```
 
-Testing against physical devices requires that you have ideviceinstaller
-installed.
 

--- a/cucumber/ios/README.md
+++ b/cucumber/ios/README.md
@@ -1,0 +1,40 @@
+## Cucumber iOS
+
+Features that demonstrate and test Calabash on iOS.
+
+### Preparing
+
+To avoid checking apps and ipas into git, you must build the
+apps from source.
+
+**TODO** It would be nice to have a public build server.
+
+Use the following rake tasks to build and install the apps and ipas
+required for testing.
+
+```
+$ cd cucumber/ios
+$ bundle
+$ be rake ensure_apps
+$ be rake ensure_ipas # Only if you need to test on physical devices.
+```
+
+You only need to run these rake tasks once.
+
+If you want to use different binaries, drop them into
+`cucumber/ios/binaries`.
+
+### Testing
+
+See the `config/cucumber.yml` for defined profiles.
+
+The Gemfile pins the calabash gem to `:path => '../../'`.
+
+```
+$ bundle
+$ be cucumber
+```
+
+Testing against physical devices requires that you have ideviceinstaller
+installed.
+

--- a/cucumber/ios/Rakefile
+++ b/cucumber/ios/Rakefile
@@ -1,3 +1,5 @@
+require 'luffa'
+
 desc 'Run Scenarios with :host strategy'
 task :host do
   sh "CAL_UIA_STRATEGY=host bundle exec cucumber"
@@ -20,33 +22,111 @@ task :strategies do
   end
 end
 
-desc 'Install a CalSmoke-cal.app for Cucumber testing.'
-task :ensure_app do
+module IOS
+  class App
+    attr :name, :repo, :source_dir, :make_dir, :rule, :product_dir
 
-  this_dir = File.dirname(__FILE__)
-  app_path = File.join(this_dir, 'CalSmoke-cal.app')
-
-  if File.exist?(app_path)
-    puts "INFO: App exists at #{app_path}"
-  else
-
-    puts "INFO: App does not exist at #{app_path}"
-    puts "INFO: Will install from sources."
-
-    unless File.exist?('./binaries')
-      sh 'git clone git@github.com:calabash/ios-smoke-test-app.git binaries'
+    def initialize(name, repo, source_dir, make_dir, rule, product_dir)
+      @name = name
+      @repo = repo
+      @source_dir = source_dir
+      @make_dir = make_dir
+      @rule = rule
+      @product_dir = product_dir
     end
 
-    working_dir = File.expand_path(File.join(this_dir, 'binaries', 'CalSmokeApp'))
-
-    Dir.chdir(working_dir) do
-      sh 'git checkout master'
-      sh 'git pull origin master'
-      sh 'make app-cal'
-      sh "mv CalSmoke-cal.app #{this_dir}"
+    def git_clone
+      cmd = "git clone --recursive --depth 1 #{repo} #{source_dir}"
+      Luffa.log_info("Cloning #{repo}")
+      Luffa.unix_command(cmd,
+                         {:fail_msg => "Could not clone #{repo}",
+                          :pass_msg => "Cloned #{repo}"})
     end
 
-    puts "Installed: #{app_path}"
+    def make(install_dir)
+      Dir.chdir(source_dir) do
+        Luffa.unix_command('git checkout master')
+        Luffa.unix_command('git pull origin master')
+        Dir.chdir(make_dir) do
+          Luffa.unix_command("make #{rule}",
+                             {:fail_msg => "Could not 'make #{rule}'",
+                              :pass_msg => "Made rule '#{rule}'"} )
+          Luffa.unix_command("mv #{File.join(product_dir, name)} #{install_dir}",
+                             {:fail_msg => "Could not install '#{name}'",
+                              :pass_msg => "Installed '#{name}'"})
+        end
+      end
+
+      Luffa.log_info("Installed: #{File.join(install_dir, name)}")
+    end
+
+    def build(install_dir)
+      unless File.exists?(source_dir)
+        git_clone
+      end
+
+      make(install_dir)
+    end
+  end
+end
+
+APPS = [
+  IOS::App.new('CalSmoke-cal.app',
+               'git@github.com:calabash/ios-smoke-test-app.git',
+               'binaries/smoke-test-app',
+               'CalSmokeApp',
+               'app-cal',
+               './'),
+
+  IOS::App.new('iPhoneOnly.app',
+               'git@github.com:calabash/ios-iphone-only-app.git',
+               'binaries/iphone-only-app',
+               './',
+               'app',
+               'Calabash-app')
+]
+
+IPAS = [
+  IOS::App.new('CalSmoke-cal.ipa',
+               'git@github.com:calabash/ios-smoke-test-app.git',
+               'binaries/smoke-test-app',
+               'CalSmokeApp',
+               'ipa-cal',
+               './xtc-staging'),
+
+  IOS::App.new('iPhoneOnly.ipa',
+               'git@github.com:calabash/ios-iphone-only-app.git',
+               'binaries/iphone-only-app',
+               './',
+               'ipa',
+               'Calabash-ipa')
+]
+
+desc 'Uninstall test binaries'
+task :clean do
+  sh 'mkdir -p ./binaries'
+  sh 'rm -rf ./binaries/*.app'
+  sh 'rm -rf ./binaries/*.ipa'
+end
+
+desc 'Install the .apps for Cucumber testing.'
+task :install_apps do
+
+  install_dir = File.join(File.dirname(__FILE__), 'binaries')
+
+  APPS.each do |app|
+
+    app_path = File.join(install_dir, app.name)
+
+    if File.exist?(app_path)
+      Luffa.log_info("App exists at #{app_path}")
+      Luffa.log_info('Done')
+    else
+      Luffa.log_info("App does not exist at #{app_path}")
+      Luffa.log_info("Will install from sources.")
+
+      app.build(install_dir)
+    end
   end
 end
 
@@ -54,33 +134,23 @@ end
 # need to set the CODE_SIGN_IDENTITY variable.
 #
 # $ CODE_SIGN_IDENTITY="iPhone Developer: Joshua Moody (8QXXXXX9F)" rake ensure_ipa
-desc 'Install a CalSmoke-cal.ipa for Cucumber testing.'
-task :ensure_ipa do
-  this_dir = File.dirname(__FILE__)
-  ipa_path = File.join(this_dir, 'CalSmoke-cal.ipa')
+desc 'Install the .ipas for Cucumber testing.'
+task :install_ipas do
+  install_dir = File.join(File.dirname(__FILE__), 'binaries')
 
-  if File.exist?(ipa_path)
-    puts "INFO: .ipa exists at #{ipa_path}"
-  else
+  IPAS.each do |app|
 
-    puts "INFO: .ipa does not exist at #{ipa_path}"
-    puts "INFO: Will install from sources."
+    app_path = File.join(install_dir, app.name)
 
-    unless File.exist?('./binaries')
-      sh 'git clone git@github.com:calabash/ios-smoke-test-app.git binaries'
+    if File.exist?(app_path)
+      Luffa.log_info("App exists at #{app_path}")
+      Luffa.log_info('Done')
+    else
+      Luffa.log_info("App does not exist at #{app_path}")
+      Luffa.log_info("Will install from sources.")
+
+      app.build(install_dir)
     end
-
-    working_dir = File.expand_path(File.join(this_dir, 'binaries', 'CalSmokeApp'))
-
-    Dir.chdir(working_dir) do
-      sh 'git checkout master'
-      sh 'git pull origin master'
-      sh 'make ipa-cal'
-      sh "mv xtc-staging/CalSmoke-cal.ipa #{this_dir}"
-    end
-
-    puts "Installed: #{ipa_path}"
   end
-  true
 end
 

--- a/cucumber/ios/config/cucumber.yml
+++ b/cucumber/ios/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 
-APP = ENV['CAL_APP'] || File.expand_path("./CalSmoke-cal.app")
-IPA = ENV['CAL_APP'] || File.expand_path("./CalSmoke-cal.ipa")
+APP = ENV['CAL_APP'] || File.expand_path("./binaries/CalSmoke-cal.app")
+IPA = ENV['CAL_APP'] || File.expand_path("./binaries/CalSmoke-cal.ipa")
 
 DEVICE="193688959205dc7eb48d603c558ede919ad8dd0d"
 ENDPOINT="http://denis.local:37265"

--- a/cucumber/ios/features/ensure_ipad_1x.feature
+++ b/cucumber/ios/features/ensure_ipad_1x.feature
@@ -1,0 +1,34 @@
+@simulator_only
+@ensure_ipad_1x
+Feature: iPhone app emulated on iPad
+In order to test iPhone apps emulated on iPads
+As a developer
+I want a way to ensure the app is displayed @ 1x zoom
+
+# Calabash cannot interact with these apps in 2x mode because the touch
+# coordinates cannot be reliably translated from normal iPhone dimensions
+# to the emulated dimensions.
+#
+# After launch, Calabash will detect that the app is being emulated on
+# an iPad and will tap the 1X/2X zoom button to get the app into the correct
+# scale.
+
+@wip
+Scenario: Ensure app in 1x
+  Given the iPhoneOnly app has launched
+  Then the app will be in 1x mode
+  Then I can tap the Moss box with UIA
+
+  Then we fail because gestures on emulated apps are broken
+
+  Then I can touch all the boxes
+
+  Then I rotate so the home button is on the right
+  Then I can touch all the boxes
+
+  Then I rotate so the home button is on the top
+  Then I can touch all the boxes
+
+  Then I rotate so the home button is on the left
+  Then I can touch all the boxes
+

--- a/cucumber/ios/features/step_definitions/ensure_ipad_1x_steps.rb
+++ b/cucumber/ios/features/step_definitions/ensure_ipad_1x_steps.rb
@@ -1,0 +1,35 @@
+
+Given(/^the iPhoneOnly app has launched$/) do
+  app = Calabash::Application.default
+  expect(app.identifier).to be == 'sh.calaba.iPhoneOnly'
+  expect(runtime_details['app_id']).to be == 'sh.calaba.iPhoneOnly'
+end
+
+Then(/^the app will be in 1x mode$/) do
+  # API is private so the real test is that we can touch the boxes
+end
+
+Then(/^I can tap the Moss box with UIA$/) do
+  wait_for_view("view {accessibilityLabel LIKE 'Moss'}")
+  uia_with_main_window("elements()['Moss'].tap()")
+  wait_for_view("UILabel marked:'Moss'")
+end
+
+Then(/^we fail because gestures on emulated apps are broken$/) do
+  raise 'Cannot perform gestures on iPhone apps emulated on iPads'
+end
+
+Then(/^I can touch all the boxes$/) do
+  box_names = [
+    'Cayenne', 'Asparagus', 'Clover', 'Midnight', 'Plum', 'Tin',
+    'Mocha', 'Fern', 'Moss'
+  ].shuffle
+
+  box_names.each do |name|
+    query = "view {accessibilityLabel LIKE '#{name}'}"
+    tap(query)
+
+    query = "UILabel marked:'#{name}'"
+    wait_for_view(query)
+  end
+end

--- a/cucumber/ios/features/support/env.rb
+++ b/cucumber/ios/features/support/env.rb
@@ -2,12 +2,7 @@ require 'calabash/ios'
 
 World(Calabash::IOS)
 
-Calabash::Application.default = Calabash::IOS::Application.default_from_environment
-
-identifier = Calabash::IOS::Device.default_identifier_for_application(Calabash::Application.default)
-server = Calabash::IOS::Server.default
-
-Calabash::Device.default = Calabash::IOS::Device.new(identifier, server)
+Calabash::IOS.setup_defaults!
 
 unless Calabash::Environment.xamarin_test_cloud?
   require 'pry'

--- a/cucumber/ios/features/support/hooks.rb
+++ b/cucumber/ios/features/support/hooks.rb
@@ -12,6 +12,18 @@ Before('@preferences') do
   @uia_strategy = :preferences
 end
 
+Before('@ensure_ipad_1x') do
+  app = Calabash::IOS::Application.new('./binaries/iPhoneOnly.app')
+  Calabash::Application.default = app
+
+  xcode_version = RunLoop::XCTools.new.xcode_version
+  simulator_version = "#{xcode_version.major + 2}.#{xcode_version.minor}"
+  simulator_name = "iPad Air (#{simulator_version} Simulator)"
+
+  server = Calabash::IOS::Server.default
+  Calabash::Device.default = Calabash::IOS::Device.new(simulator_name, server)
+end
+
 Before do |scenario|
   if scenario.respond_to?(:scenario_outline)
     scenario = scenario.scenario_outline
@@ -27,6 +39,10 @@ Before do |scenario|
   end
 
   start_app(options)
+end
+
+After('@ensure_ipad_1x') do
+  Calabash::IOS.setup_defaults!
 end
 
 After do

--- a/lib/calabash/ios/device.rb
+++ b/lib/calabash/ios/device.rb
@@ -18,6 +18,7 @@ module Calabash
     require 'calabash/ios/device/uia_keyboard_mixin'
     require 'calabash/ios/device/text_mixin'
     require 'calabash/ios/device/uia_mixin'
+    require 'calabash/ios/device/ipad_1x_2x_mixin'
     require 'calabash/ios/device/device_implementation'
 
   end

--- a/lib/calabash/ios/device/device_implementation.rb
+++ b/lib/calabash/ios/device/device_implementation.rb
@@ -19,7 +19,7 @@ module Calabash
       include Calabash::IOS::UIAKeyboardMixin
       include Calabash::IOS::TextMixin
       include Calabash::IOS::UIAMixin
-
+      include Calabash::IOS::IPadMixin
       include Calabash::IOS::GesturesMixin
 
       attr_reader :run_loop
@@ -339,6 +339,10 @@ module Calabash
         else
           raise "Invalid application #{application} for iOS platform."
         end
+
+        # @todo Get the language code from the server!
+        ensure_ipad_emulation_1x
+
         {
            :device => self,
            :application => application,

--- a/lib/calabash/ios/device/ipad_1x_2x_mixin.rb
+++ b/lib/calabash/ios/device/ipad_1x_2x_mixin.rb
@@ -1,0 +1,253 @@
+module Calabash
+  module IOS
+    # @!visibility private
+    # Contains methods for interacting with the iPad.
+    module IPadMixin
+
+      # @!visibility private
+      # Provides methods to interact with the 1x and 2x buttons that appear
+      # when an iPhone-only app is emulated on an iPad.  Calabash cannot
+      # interact with these apps in 2x mode because the touch coordinates
+      # cannot be reliably translated from normal iPhone dimensions to the
+      # emulated dimensions.
+      #
+      # On iOS < 7, an app _remembered_ its last 1x/2x scale so when it
+      # reopened the previous scale would be the same as when it closed.  This
+      # meant you could manually set the scale once to 1x and never have to
+      # interact with the scale button again.
+      #
+      # On iOS > 7, the default behavior is that all emulated apps open at 2x
+      # regardless of their previous scale.
+      #
+      # @note In order to use this class, you must allow Calabash to launch
+      #  your app with instruments.
+      class Emulation
+
+        # @!visibility private
+        #
+        # Maintainers:  when adding a localization, please notice that
+        # the keys and values are semantically reversed.
+        #
+        # you should read the hash as:
+        #
+        # ```
+        # :emulated_1x <= what button is showing when the app is emulated at 2X?
+        # :emulated_2x <= what button is showing when the app is emulated at 1X?
+        # ```
+        #
+        # @todo Once we have localizations wired up, we can use these keys
+        #
+        # These pull requests describe how to find a key/value pairs from the
+        # on-disk accessibility bundles for _keyboards_ but we can use the same
+        # strategy to look up the Zoom button localizations.
+        #
+        # * https://github.com/calabash/run_loop/pull/197
+        # * https://github.com/calabash/calabash-ios-server/pull/221
+        #
+        #
+        #  fullscreen.zoom => 2x => 'Switch to full screen mode'
+        #  normal.zoom => 1x => 'Switch to normal mode'
+        #
+        #  # We will still need query windows.
+        #  uia("UIATarget.localTarget().frontMostApp().windows()[2].elements()[0].label()")
+        IPAD_1X_2X_BUTTON_LABELS = {
+              :en => {:emulated_1x => '2X',
+                      :emulated_2x => '1X'}
+        }
+
+        # @!visibility private
+        # @!attribute [r] scale
+        # The current 1X or 2X scale represented as a Symbol.
+        #
+        # @return [Symbol] Returns this emulation's scale.  Will be one of
+        # `{:emulated_1x | :emulated_2x}`.
+        attr_reader :scale
+
+        # @!visibility private
+        # @!attribute [r] lang_code
+        # The Apple compatible language code for determining the accessibility
+        # label of the 1X and 2X buttons.
+        #
+        # @return [Symbol] Returns the language code of this emulation.
+        attr_reader :lang_code
+
+        # @!visibility private
+        # @!attribute [r] device
+        # A handle on the default device.
+        attr_reader :device
+
+        # @!visibility private
+        # A private instance variable for storing this emulation's 1X/2X button
+        # names.  The value will be set at runtime based on the language code
+        # that is passed the initializer.
+        @button_names_hash = nil
+
+        # @!visibility private
+        # Creates a new Emulation.
+        # @param [Symbol] lang_code an Apple compatible language code
+        # @return [Emulation] Returns an emulation that is ready for action!
+        def initialize (device, lang_code=:en)
+          @button_names_hash = IPAD_1X_2X_BUTTON_LABELS[lang_code]
+          if @button_names_hash.nil?
+            raise "could not find 1X/2X buttons for language code '#{lang_code}'"
+          end
+
+          @device = device
+          @lang_code = lang_code
+          @scale = _internal_ipad_emulation_scale
+        end
+
+        # @!visibility private
+        def tap_ipad_scale_button
+          key = @scale
+          name = @button_names_hash[key]
+
+          query_args =
+          [
+               [
+                 :view, {:marked => "#{name}"}
+               ]
+          ]
+
+          device.uia_query_then_make_javascript_calls(:queryElWindows, query_args, :tap)
+        end
+
+        private
+
+        # @!visibility private
+        def _internal_ipad_emulation_scale
+          hash = @button_names_hash
+          val = nil
+          hash.values.each do |button_name|
+            query_args =
+                  [
+                        :view, {:marked => button_name}
+                  ]
+
+            button_exists = device.uia_serialize_and_call(:queryElWindows,
+                                                          query_args)
+            if button_exists
+              result = device.uia_query_then_make_javascript_calls(:queryElWindows,
+                                                                   [query_args],
+                                                                   :name)
+              if result == button_name
+                val = button_name
+                break
+              end
+            end
+          end
+
+          if val.nil?
+            raise "Could not find iPad scale button with '#{hash.values}'"
+          end
+
+          if val == hash[:emulated_1x]
+            :emulated_1x
+          elsif val == hash[:emulated_2x]
+            :emulated_2x
+          else
+            raise "Unrecognized emulation scale '#{val}'"
+          end
+        end
+      end
+
+      # @!visibility private
+      # Ensures that iPhone apps emulated on an iPad are displayed at scale.
+      #
+      # @note It is recommended that clients call this `ensure_ipad_emulation_1x`
+      #  instead of this method.
+      #
+      # @note If this is not an iPhone app emulated on an iPad, then calling
+      #  this method has no effect.
+      #
+      # @note In order to use this method, you must allow Calabash to launch
+      #  your app with instruments.
+      #
+      # Starting in iOS 7, iPhone apps emulated on the iPad always launch at 2x.
+      # calabash cannot currently interact with such apps in 2x mode (trust us,
+      # we've tried).
+      #
+      # @see #ensure_ipad_emulation_1x
+      #
+      # @param [Symbol] scale the desired scale - must be `:emulated_1x` or
+      #  `:emulated_2x`
+      #
+      # @param [Hash] opts optional arguments to control the interaction with
+      #  the 1X/2X buttons
+      #
+      # @option opts [Symbol] :lang_code (:en) an Apple compatible
+      #  language code
+      # @option opts [Symbol] :wait_after_touch (0.4) how long to
+      #  wait _after_ the scale button is touched
+      #
+      # @return [void]
+      #
+      # @raise [RuntimeError] If the app was not launched with instruments.
+      # @raise [RuntimeError] If an invalid `scale` is passed.
+      # @raise [RuntimeError] If an unknown language code is passed.
+      # @raise [RuntimeError] If the scale button cannot be touched.
+      def ensure_ipad_emulation_scale(scale, opts={})
+        return unless iphone_app_emulated_on_ipad?
+
+        allowed = [:emulated_1x, :emulated_2x]
+        unless allowed.include?(scale)
+          raise "Scale '#{scale}' is not one of '#{allowed}' allowed args"
+        end
+
+        default_opts = {:lang_code => :en,
+                        :wait_after_touch => 0.4}
+        merged_opts = default_opts.merge(opts)
+
+        obj = Emulation.new(self, merged_opts[:lang_code])
+
+        actual_scale = obj.scale
+
+        if actual_scale != scale
+          obj.tap_ipad_scale_button
+        end
+
+        sleep(merged_opts[:wait_after_touch])
+      end
+
+      # @!visibility private
+      # Ensures that iPhone apps emulated on an iPad are displayed at `1X`.
+      #
+      # @note If this is not an iPhone app emulated on an iPad, then calling
+      #  this method has no effect.
+      #
+      # @note In order to use this method, you must allow Calabash to launch
+      #  your app with instruments.
+      #
+      # Starting in iOS 7, iPhone apps emulated on the iPad always launch at 2x.
+      # calabash cannot currently interact with such apps in 2x mode (trust us,
+      # we've tried).
+      #
+      # @param [Hash] opts optional arguments to control the interaction with
+      #  the 1X/2X buttons
+      #
+      # @option opts [Symbol] :lang_code (:en) an Apple compatible
+      #  language code
+      # @option opts [Symbol] :wait_after_touch (0.4) how long to
+      #  wait _after_ the scale button is touched
+      #
+      # @return [void]
+      #
+      # @raise [RuntimeError] If the app was not launched with instruments.
+      # @raise [RuntimeError] If an unknown language code is passed.
+      # @raise [RuntimeError] If the scale button cannot be touched.
+      def ensure_ipad_emulation_1x(opts={})
+        ensure_ipad_emulation_scale(:emulated_1x, opts)
+      end
+
+      private
+      # @!visibility private
+      # Ensures iPhone apps running on an iPad are emulated at 2X
+      #
+      # You should never need to call this function - Calabash cannot interact
+      # with iPhone apps emulated on the iPad in 2x mode.
+      def _ensure_ipad_emulation_2x(opts={})
+        ensure_ipad_emulation_scale(:emulated_2x, opts)
+      end
+    end
+  end
+end

--- a/lib/calabash/ios/device/routes/uia_route_mixin.rb
+++ b/lib/calabash/ios/device/routes/uia_route_mixin.rb
@@ -50,6 +50,13 @@ module Calabash
           end
         end
 
+        # @!visibility private
+        def uia_serialize_and_call(uia_command, *query_args)
+          command = uia_serialize_command(uia_command, *query_args)
+          result = uia_route(command)
+          result.first
+        end
+
         private
 
         UIA_STRATEGIES = [:preferences, :host, :shared_element]
@@ -158,12 +165,6 @@ module Calabash
           rescue => e
             raise Calabash::IOS::RouteError, e
           end
-        end
-
-        def uia_serialize_and_call(uia_command, *query_args)
-          command = uia_serialize_command(uia_command, *query_args)
-          result = uia_route(command)
-          result.first
         end
 
         # @todo Verify this is the correct way to escape '\n in string

--- a/lib/calabash/ios/runtime.rb
+++ b/lib/calabash/ios/runtime.rb
@@ -63,6 +63,14 @@ module Calabash
       end
 
       # Is the device under test an iPhone 3.5in?
+      #
+      # @note If the app under test is an iPhone app emulated on an iPad then
+      #  the form factor will _always_ be 'iphone 3.5.in'.  If you need to
+      #  branch on the actual device the app is running on, use the #ipad?
+      #  method.
+      #
+      # @see #iphone_app_emulated_on_ipad?
+      # @see #ipad?
       def iphone_35in?
         Calabash::IOS::Device.default.form_factor == 'iphone 3.5in'
       end

--- a/spec/lib/ios/device/device_spec.rb
+++ b/spec/lib/ios/device/device_spec.rb
@@ -245,6 +245,7 @@ describe Calabash::IOS::Device do
       it 'calls start_app_on_simulator when app is a simulator bundle' do
         expect(app).to receive(:simulator_bundle?).and_return true
         expect(device).to receive(:start_app_on_simulator).with(app, options).and_return true
+        expect(device).to receive(:ensure_ipad_emulation_1x).and_return true
 
         expect(device.start_app(app, options)).to be_truthy
       end
@@ -253,6 +254,7 @@ describe Calabash::IOS::Device do
         expect(app).to receive(:simulator_bundle?).and_return false
         expect(app).to receive(:device_binary?).and_return true
         expect(device).to receive(:start_app_on_physical_device).with(app, options).and_return true
+        expect(device).to receive(:ensure_ipad_emulation_1x).and_return true
 
         expect(device.start_app(app, options)).to be_truthy
       end


### PR DESCRIPTION
### Motivation

Calabash cannot translate coordinates from the 2x space.

There is a bug and a failing cucumber:

**Cannot touch views on iPhone apps emulated on iPad - even in 1X mode** [Calabash iOS 0.x #813](https://github.com/calabash/calabash-ios/issues/813)