### PR TITLE
Remove unnecessary screenshot methods

### DIFF
--- a/lib/calabash/lib/skeleton/features/support/hooks.rb.skeleton
+++ b/lib/calabash/lib/skeleton/features/support/hooks.rb.skeleton
@@ -12,7 +12,11 @@ Before do |scenario|
   end
 end
 
-After do
+After do |scenario|
+  if scenario.failed?
+    cal.screenshot_embed
+  end
+
   cal.stop_app
 end
 

--- a/lib/calabash/wait.rb
+++ b/lib/calabash/wait.rb
@@ -21,10 +21,7 @@ module Calabash
             retry_frequency: 0.1,
 
             # default exception type to raise when the timeout is exceeded
-            exception_class: Calabash::Wait::TimeoutError,
-
-            # whether to embed a screenshot on failure
-            screenshot_on_error: true
+            exception_class: Calabash::Wait::TimeoutError
         }
 
     # Returns the default wait options.
@@ -124,8 +121,6 @@ module Calabash
     # @option options [Number] :timeout (30) How long to wait before timing out.
     # @option options [Number] :retry_frequency (0.3) How often to check for
     #  the condition block to be truthy.
-    # @option options [Boolean] :screenshot_on_error (true) Take a screenshot
-    #  if the block fails to be truthy or an error is raised in the block.
     # @return The returned value of `block` if it is truthy
     def wait_for(timeout_message, options={}, &block)
       wait_options = Wait.default_options.merge(options)
@@ -402,67 +397,6 @@ module Calabash
     # @see Calabash::Wait#wait_for_no_view
     def wait_for_text_to_disappear(text, options={})
       wait_for_no_view("* {text CONTAINS[c] '#{text}'}", options)
-    end
-
-    # Raises an exception. Embeds a screenshot if
-    # Calabash::Wait#default_options[:screenshot_on_error] is true. The fail
-    # method should be used when the test should fail and stop executing. Do
-    # not use fail if you intent on rescuing the error raised without
-    # re-raising.
-    #
-    # @example
-    #  unless view_exists?("* marked:'login'")
-    #    fail('Did not see "login" button')
-    #  end
-    #
-    # @example
-    #  entries = query("ListEntry").length
-    #
-    #  if entries < 5
-    #    fail(MyError, "Should see at least 5 entries, saw #{entries}")
-    #  end
-    #
-    # @raise [RuntimeError, StandardError] By default, raises a RuntimeError with
-    #  `message`.  You can pass in your own Exception class to override the
-    #  the default behavior.
-    def fail(*several_variants)
-      arg0 = several_variants[0]
-      arg1 = several_variants[1]
-
-      if arg1.nil?
-        exception_type = RuntimeError
-        message = arg0
-      else
-        exception_type = arg0
-        message = arg1
-      end
-
-      screenshot_embed if Wait.default_options[:screenshot_on_error]
-
-      raise exception_type, message
-    end
-
-    # Raises an exception and always embeds a screenshot
-    #
-    # @raise [RuntimeError, StandardError] By default, raises a RuntimeError with
-    #  `message`.  You can pass in your own Exception class to override the
-    #  the default behavior.
-    # @see Wait#fail
-    def screenshot_and_raise(*several_variants)
-      arg0 = several_variants[0]
-      arg1 = several_variants[1]
-
-      if arg1.nil?
-        exception_type = RuntimeError
-        message = arg0
-      else
-        exception_type = arg0
-        message = arg1
-      end
-
-      screenshot_embed
-
-      raise exception_type, message
     end
 
     # @!visibility private

--- a/spec/lib/wait_spec.rb
+++ b/spec/lib/wait_spec.rb
@@ -2,7 +2,6 @@ describe Calabash::Wait do
   let(:dummy) do
     Class.new do
       include Calabash::Wait
-      def screenshot_embed; ; end
       def query(_); ; end
     end.new
   end
@@ -22,7 +21,6 @@ describe Calabash::Wait do
       expect(default_options[:message].call({timeout: 10})).to eq("Timed out after waiting for 10 seconds...")
       expect(default_options[:retry_frequency]).to eq(0.1)
       expect(default_options[:exception_class]).to eq(Calabash::Wait::TimeoutError)
-      expect(default_options[:screenshot_on_error]).to eq(true)
 
       load wait_file
     end
@@ -34,7 +32,6 @@ describe Calabash::Wait do
       Calabash::Wait.default_options[:message] = 'test'
       Calabash::Wait.default_options[:retry_frequency] = 1
       Calabash::Wait.default_options[:exception_class] = String
-      Calabash::Wait.default_options[:screenshot_on_error] = false
 
       default_options = Calabash::Wait.default_options
 
@@ -42,7 +39,6 @@ describe Calabash::Wait do
       expect(default_options[:message]).to eq('test')
       expect(default_options[:retry_frequency]).to eq(1)
       expect(default_options[:exception_class]).to eq(String)
-      expect(default_options[:screenshot_on_error]).to eq(false)
 
       load wait_file
     end
@@ -191,28 +187,6 @@ describe Calabash::Wait do
       expect(dummy.wait_for('msg', timeout: 10) do
         dummy.test
       end).to eq('truthy')
-    end
-  end
-
-  describe '#fail' do
-    it 'should fail with a given message and error' do
-      my_error = Class.new(RuntimeError)
-      my_message = 'My message'
-
-      expect{dummy.fail(my_message)}.to raise_error(RuntimeError, my_message)
-      expect{dummy.fail(my_error, my_message)}.to raise_error(my_error, my_message)
-    end
-
-    it 'should take a screenshot if screenshot_on_error is true' do
-      Calabash::Wait.default_options[:screenshot_on_error] = true
-      expect(dummy).to receive(:screenshot_embed).once
-      expect{dummy.fail('Message')}.to raise_error RuntimeError
-    end
-
-    it 'should not take a screenshot if screenshot_on_error is false' do
-      Calabash::Wait.default_options[:screenshot_on_error] = false
-      expect(dummy).not_to receive(:screenshot_embed)
-      expect{dummy.fail('Message')}.to raise_error RuntimeError
     end
   end
 


### PR DESCRIPTION
It should be up to the test runner to determine if/when a screenshot
should be taken. We should never automatically take screenshots.

We don't need special methods like fail either then.