### PR TITLE
All calls to default device goes through method

### DIFF
--- a/lib/calabash.rb
+++ b/lib/calabash.rb
@@ -30,6 +30,7 @@ module Calabash
   require 'calabash/defaults'
   require 'calabash/legacy'
   require 'calabash/console_helpers'
+  require 'calabash/internal'
 
 
   require 'calabash/patch'

--- a/lib/calabash/android/gestures.rb
+++ b/lib/calabash/android/gestures.rb
@@ -347,15 +347,15 @@ module Calabash
 
       # @!visibility private
       define_method(:_pinch_screen) do |options={}|
-        Device.default.pinch(direction, "* id:'content'", options)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.pinch(direction, "* id:'content'", options)}
       end
 
       # @!visibility private
       define_method(:_pinch_to_zoom) do |options={}|
         if direction == :out
-          Device.default.pinch(:in, query, options)
+          Calabash::Internal.with_default_device(required_os: :android) {|device| device.pinch(:in, query, options)}
         elsif direction == :in
-          Device.default.pinch(:out, query, options)
+          Calabash::Internal.with_default_device(required_os: :android) {|device| device.pinch(:out, query, options)}
         else
           raise "Invalid direction '#{direction}'"
         end

--- a/lib/calabash/android/interactions.rb
+++ b/lib/calabash/android/interactions.rb
@@ -8,13 +8,13 @@ module Calabash
     module Interactions
       # Go back. If the keyboard is shown, it will be dismissed.
       def go_back
-        Device.default.perform_action('hide_soft_keyboard')
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('hide_soft_keyboard')}
         press_back_button
       end
 
       # Go to the home screen.
       def go_home
-        Device.default.go_home
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.go_home}
 
         true
       end
@@ -27,7 +27,7 @@ module Calabash
       #
       # @return [String] The name of the currently focused activity.
       def focused_activity
-        Device.default.current_focus[:activity]
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.current_focus[:activity]}
       end
 
       # Get the name of the currently focused package
@@ -38,7 +38,7 @@ module Calabash
       #
       # @return [String] The name of the currently focused package
       def focused_package
-        Device.default.current_focus[:package]
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.current_focus[:package]}
       end
 
       # Sets the date of the first visible date picker widget.
@@ -142,7 +142,7 @@ module Calabash
 
       # @!visibility private
       define_method(:_evaluate_javascript_in) do |query, javascript|
-        Device.default.evaluate_javascript_in(query, javascript)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.evaluate_javascript_in(query, javascript)}
       end
     end
   end

--- a/lib/calabash/android/life_cycle.rb
+++ b/lib/calabash/android/life_cycle.rb
@@ -21,7 +21,7 @@ module Calabash
           raise 'No application given, and Application.default is not set'
         end
 
-        Device.default.resume_app(path_or_application)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.resume_app(path_or_application)}
 
         true
       end
@@ -33,7 +33,7 @@ module Calabash
 
         go_home
         sleep(for_seconds)
-        Device.default.resume_activity(package, activity)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.resume_activity(package, activity)}
       end
     end
   end

--- a/lib/calabash/android/orientation.rb
+++ b/lib/calabash/android/orientation.rb
@@ -4,12 +4,12 @@ module Calabash
     module Orientation
       # @!visibility private
       define_method(:_set_orientation_landscape) do
-        Device.default.perform_action('set_activity_orientation', 'landscape')
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('set_activity_orientation', 'landscape')}
       end
 
       # @!visibility private
       define_method(:_set_orientation_portrait) do
-        Device.default.perform_action('set_activity_orientation', 'portrait')
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('set_activity_orientation', 'portrait')}
       end
 
       # @!visibility private
@@ -24,7 +24,7 @@ module Calabash
 
       # @!visibility private
       define_method(:_orientation) do
-        Device.default.perform_action('get_activity_orientation')['message']
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('get_activity_orientation')['message']}
       end
     end
   end

--- a/lib/calabash/android/physical_buttons.rb
+++ b/lib/calabash/android/physical_buttons.rb
@@ -9,7 +9,7 @@ module Calabash
 
       # @!visibility private
       def press_button(key)
-        Device.default.perform_action('press_key', key)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('press_key', key)}
         true
       end
 

--- a/lib/calabash/android/text.rb
+++ b/lib/calabash/android/text.rb
@@ -6,13 +6,13 @@ module Calabash
       # pressing the back button if the keyboard is showing. If the keyboard is
       # already hidden/dismissed, nothing is done.
       def dismiss_keyboard
-        Device.default.perform_action('hide_soft_keyboard')
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('hide_soft_keyboard')}
         sleep 0.5
       end
 
       # @!visibility private
       define_method(:_clear_text) do
-        Device.default.perform_action('clear_text')
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('clear_text')}
       end
 
       # @!visibility private
@@ -24,7 +24,7 @@ module Calabash
 
       # @!visibility private
       define_method(:_enter_text) do |text|
-        Device.default.enter_text(text)
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.enter_text(text)}
       end
 
       # @!visibility private
@@ -37,15 +37,15 @@ module Calabash
       # @!visibility private
       define_method(:_tap_keyboard_action_key) do |action_key|
         if action_key.nil?
-          Device.default.perform_action('press_user_action_button')
+          Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('press_user_action_button')}
         else
-          Device.default.perform_action('press_user_action_button', action_key.to_s)
+          Calabash::Internal.with_default_device(required_os: :android) {|device| device.perform_action('press_user_action_button', action_key.to_s)}
         end
       end
 
       # @!visibility private
       define_method(:_keyboard_visible?) do
-        Device.default.keyboard_visible?
+        Calabash::Internal.with_default_device(required_os: :android) {|device| device.keyboard_visible?}
       end
     end
   end

--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -86,7 +86,7 @@ module Calabash
 
     # Outputs all visible elements as a tree.
     def tree
-      ConsoleHelpers.dump(Device.default.dump)
+      ConsoleHelpers.dump(Calabash::Internal.with_default_device {|device| device.dump})
       true
     end
 

--- a/lib/calabash/gestures.rb
+++ b/lib/calabash/gestures.rb
@@ -47,7 +47,7 @@ module Calabash
     def tap(query, options={})
       Query.ensure_valid_query(query)
 
-      Device.default.tap(Query.new(query), options)
+      Calabash::Internal.with_default_device {|device| device.tap(Query.new(query), options)}
     end
 
     # Performs a **double_tap** on the first view that matches `query`.
@@ -66,7 +66,7 @@ module Calabash
     def double_tap(query, options={})
       Query.ensure_valid_query(query)
 
-      Device.default.double_tap(Query.new(query), options)
+      Calabash::Internal.with_default_device {|device| device.double_tap(Query.new(query), options)}
     end
 
     # Performs a **long_press** on the first view that matches `query`.
@@ -86,7 +86,7 @@ module Calabash
     def long_press(query, options={})
       Query.ensure_valid_query(query)
 
-      Device.default.long_press(Query.new(query), options)
+      Calabash::Internal.with_default_device {|device| device.long_press(Query.new(query), options)}
     end
 
     # Performs a **pan** on the first view that matches `query`.
@@ -142,7 +142,7 @@ module Calabash
 
       gesture_options = Utility.default_hash_values(options, DEFAULT_PAN_OPTIONS)
 
-      Device.default.pan(Query.new(query), from, to, gesture_options)
+      Calabash::Internal.with_default_device {|device| device.pan(Query.new(query), from, to, gesture_options)}
     end
 
     # Performs a **pan** from the center of the first view that matches
@@ -185,7 +185,7 @@ module Calabash
 
       gesture_options = Utility.default_hash_values(options, DEFAULT_PAN_OPTIONS)
 
-      Device.default.pan_between(Query.new(query_from), Query.new(query_to), gesture_options)
+      Calabash::Internal.with_default_device {|device| device.pan_between(Query.new(query_from), Query.new(query_to), gesture_options)}
     end
 
     # Performs a **pan** heading _left_ on the first view that matches `query`.
@@ -287,7 +287,7 @@ module Calabash
     def flick(query, from, to, options={})
       Query.ensure_valid_query(query)
 
-      Device.default.flick(Query.new(query), from, to, options)
+      Calabash::Internal.with_default_device {|device| device.flick(Query.new(query), from, to, options)}
     end
 
     # Performs a **flick** heading _left_ on the first view that matches `query`.
@@ -351,7 +351,7 @@ module Calabash
     # @raise [ArgumentError] If `query` is invalid.
     # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_out(query, options={})
-      Device.default.pinch(:out, query, options)
+      Calabash::Internal.with_default_device {|device| device.pinch(:out, query, options)}
     end
 
     # Performs a **pinch** inwards on the first view match by `query`.
@@ -366,7 +366,7 @@ module Calabash
     # @raise [ArgumentError] If `query` is invalid.
     # @raise [ArgumentError] iOS: if the `:duration` is not between 0.5 and 60.
     def pinch_in(query, options={})
-      Device.default.pinch(:in, query, options)
+      Calabash::Internal.with_default_device {|device| device.pinch(:in, query, options)}
     end
 
     # Performs a **pinch** outwards on the screen.

--- a/lib/calabash/interactions.rb
+++ b/lib/calabash/interactions.rb
@@ -62,7 +62,7 @@ module Calabash
     #
     # @return [Calabash::QueryResult] A result of the query
     def query(query, *args)
-      Calabash::Device.default.map_route(Query.new(query), :query, *args)
+      Calabash::Internal.with_default_device {|device| device.map_route(Query.new(query), :query, *args)}
     end
 
     # Flashes any views matching `query`. Only one view is flashed at a time,
@@ -71,7 +71,7 @@ module Calabash
     # @param [String, Hash, Calabash::Query] query The query to match the
     #  view(s)
     def flash(query)
-      Calabash::Device.default.map_route(Query.new(query), :flash)
+      Calabash::Internal.with_default_device {|device| device.map_route(Query.new(query), :flash)}
     end
 
     # Evaluate javascript in a Web View. On iOS, an implicit return is
@@ -158,7 +158,7 @@ module Calabash
     # @return [Object] the result of performing the selector/method with the
     #  arguments (serialized)
     def backdoor(name, *arguments)
-      Device.default.backdoor(name, *arguments)
+      Calabash::Internal.with_default_device {|device| device.backdoor(name, *arguments)}
     end
 
     # @!visibility private

--- a/lib/calabash/internal.rb
+++ b/lib/calabash/internal.rb
@@ -1,0 +1,48 @@
+module Calabash
+  # @!visibility private
+  # Internal usage, NOT a public API
+  module Internal
+    def self.with_default_device(required_os: nil, &block)
+      unless block
+        raise ArgumentError, "No block given"
+      end
+
+      device = Calabash.default_device
+
+      if device.nil?
+        raise "The default device is not set. Set it using Calabash.default_device = ..."
+      end
+
+      if required_os
+        required_class = nil
+        required_type = nil
+        current_type = nil
+
+        case required_os
+          when :ios
+            required_class = Calabash::IOS::Device
+            required_type = 'iOS'
+          when :android
+            required_class = Calabash::Android::Device
+            required_type = 'Android'
+          else
+            raise ArgumentError, "Unknown OS '#{required_os}'"
+        end
+
+        if Calabash::Android.const_defined?(:Device, false) && device.is_a?(Calabash::Android::Device)
+            current_type = 'Android'
+        elsif Calabash::IOS.const_defined?(:Device, false) && device.is_a?(Calabash::IOS::Device)
+            current_type = 'iOS'
+        else
+            current_type = 'unknown'
+        end
+
+        unless device.is_a?(required_class)
+          raise "The default device is not set to an #{required_type} device, it is an #{current_type} device."
+        end
+      end
+
+      block.call(device)
+    end
+  end
+end

--- a/lib/calabash/ios/conditions.rb
+++ b/lib/calabash/ios/conditions.rb
@@ -72,7 +72,7 @@ module Calabash
       # @return [nil] When the condition is satisfied.
       # @raise [Calabash::Wait::TimeoutError] When the timeout is exceeded.
       def wait_for_condition(condition, timeout, timeout_message, query='*')
-        unless Device.default.condition_route(condition, timeout, query)
+        unless Calabash::Internal.with_default_device(required_os: :ios) {|device| device.condition_route(condition, timeout, query)}
           raise Calabash::Wait::TimeoutError, timeout_message
         end
         true

--- a/lib/calabash/ios/console_helpers.rb
+++ b/lib/calabash/ios/console_helpers.rb
@@ -55,7 +55,7 @@ module Calabash
       Calabash::Device.default = device
 
       begin
-        Calabash::Device.default.ensure_test_server_ready({:timeout => 4})
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.ensure_test_server_ready({:timeout => 4})}
       rescue RuntimeError => e
         if e.to_s == 'Calabash server did not respond'
           raise RuntimeError, 'You can only attach to a running Calabash iOS App'
@@ -65,7 +65,7 @@ module Calabash
       end
 
       run_loop_device = device.send(:run_loop_device)
-      result = Calabash::Device.default.send(:attach_to_run_loop, run_loop_device, uia_strategy)
+      result = Calabash::Internal.with_default_device(required_os: :ios) {|device| device.send(:attach_to_run_loop, run_loop_device, uia_strategy)}
       result[:application] = Calabash::Application.default
       result
     end

--- a/lib/calabash/ios/date_picker.rb
+++ b/lib/calabash/ios/date_picker.rb
@@ -378,14 +378,16 @@ module Calabash
         objc_format = date_picker_objc_date_format
         target_date_string = date_time.strftime(ruby_format).squeeze(' ').strip
 
-        Device.default.map_route(query,
-                                 :changeDatePickerDate,
-                                 target_date_string,
-                                 objc_format,
-                                 # notify targets
-                                 true,
-                                 # animate
-                                 true)
+        Calabash::Internal.with_default_device(required_os: :ios) do |device|
+          device.map_route(query,
+                           :changeDatePickerDate,
+                           target_date_string,
+                           objc_format,
+                           # notify targets
+                           true,
+                           # animate
+                           true)
+        end
       end
 
       private

--- a/lib/calabash/ios/gestures.rb
+++ b/lib/calabash/ios/gestures.rb
@@ -26,7 +26,7 @@ module Calabash
         swipe = _swipe_coordinates_for_screen
         gesture_options = options.merge({offset: {from: swipe[:bottom], to: swipe[:top]}})
 
-        Device.default.pan_between(nil, nil, gesture_options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.pan_between(nil, nil, gesture_options)}
       end
 
       # @!visibility private
@@ -35,7 +35,7 @@ module Calabash
         swipe = _swipe_coordinates_for_screen
         gesture_options = options.merge({offset: {from: swipe[:top], to: swipe[:bottom]}})
 
-        Device.default.pan_between(nil, nil, gesture_options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.pan_between(nil, nil, gesture_options)}
       end
 
       # @!visibility private
@@ -44,7 +44,7 @@ module Calabash
         swipe = _swipe_coordinates_for_screen
         gesture_options = options.merge({offset: {from: swipe[:bottom], to: swipe[:top]}})
 
-        Device.default.flick_between(nil, nil, gesture_options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.flick_between(nil, nil, gesture_options)}
       end
 
       # @!visibility private
@@ -53,27 +53,27 @@ module Calabash
         swipe = _swipe_coordinates_for_screen
         gesture_options = options.merge({offset: {from: swipe[:top], to: swipe[:bottom]}})
 
-        Device.default.flick_between(nil, nil, gesture_options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.flick_between(nil, nil, gesture_options)}
       end
 
       # @!visibility private
       # Concrete implementation of pinch_screen
       define_method (:_pinch_screen) do |direction, options={}|
-        Device.default.pinch(direction, '*', options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.pinch(direction, '*', options)}
       end
 
       # @!visibility private
       # Concrete implementation of pinch_to_zoom
       define_method (:_pinch_to_zoom) do |direction, query, options={}|
         gesture_direction = direction == :in ? :out : :in
-        Device.default.pinch(gesture_direction, query, options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.pinch(gesture_direction, query, options)}
       end
 
       # @!visibility private
       # Concrete implementation of pinch_screen_to_zoom
       define_method (:_pinch_screen_to_zoom) do |direction, options={}|
         gesture_direction = direction == :in ? :out : :in
-        Device.default.pinch(gesture_direction, '*', options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.pinch(gesture_direction, '*', options)}
       end
 
       private

--- a/lib/calabash/ios/orientation.rb
+++ b/lib/calabash/ios/orientation.rb
@@ -13,7 +13,7 @@ module Calabash
       # @return [String] Returns the device orientation as one of
       #  `{'down' | 'up' | 'left' | 'right'}`.
       def status_bar_orientation
-        Device.default.status_bar_orientation
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.status_bar_orientation}
       end
 
       # Rotate the device left - clockwise relative to the home button.
@@ -26,7 +26,7 @@ module Calabash
       # @return [String] The position of the home button relative to the status
       #  bar after the rotation. Can be one of 'down', 'left', 'right', 'up'.
       def rotate_device_left
-        Device.default.rotate(:left)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.rotate(:left)}
         status_bar_orientation
       end
 
@@ -40,7 +40,7 @@ module Calabash
       # @return [String] The position of the home button relative to the status
       #  bar after the rotation. Can be one of 'down', 'left', 'right', 'up'.
       def rotate_device_right
-        Device.default.rotate(:right)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.rotate(:right)}
         status_bar_orientation
       end
 
@@ -83,7 +83,7 @@ module Calabash
         canonical_position = :down if position.to_sym == :bottom
         canonical_position = :up if position.to_sym == :top
 
-        Calabash::Device.default.rotate_home_button_to(canonical_position)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.rotate_home_button_to(canonical_position)}
       end
 
       # @!visibility private

--- a/lib/calabash/ios/runtime.rb
+++ b/lib/calabash/ios/runtime.rb
@@ -11,27 +11,27 @@ module Calabash
 
       # Is the device under test a simulator?
       def simulator?
-        Calabash::IOS::Device.default.simulator?
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.simulator?}
       end
 
       # Is the device under test a physical device?
       def physical_device?
-        Calabash::IOS::Device.default.physical_device?
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.physical_device?}
       end
 
       # Is the device under test an iPad?
       def ipad?
-        Calabash::IOS::Device.default.device_family == 'iPad'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.device_family == 'iPad'}
       end
 
       # Is the device under test an iPhone?
       def iphone?
-        Calabash::IOS::Device.default.device_family == 'iPhone'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.device_family == 'iPhone'}
       end
 
       # Is the device under test an iPod?
       def ipod?
-        Calabash::IOS::Device.default.device_family == 'iPod'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.device_family == 'iPod'}
       end
 
       # Is the device under test an iPhone or iPod?
@@ -44,22 +44,22 @@ module Calabash
       # An iPhone only app running on an iPad will be displayed in an emulated
       # mode.  Starting in iOS 7, such apps will always be launched in 2x mode.
       def iphone_app_emulated_on_ipad?
-        Calabash::IOS::Device.default.iphone_app_emulated_on_ipad?
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.iphone_app_emulated_on_ipad?}
       end
 
       # Is the device under test have a 4 inch screen?
       def iphone_4in?
-        Calabash::IOS::Device.default.form_factor == 'iphone 4in'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.form_factor == 'iphone 4in'}
       end
 
       # Is the device under test an iPhone 6.
       def iphone_6?
-        Calabash::IOS::Device.default.form_factor == 'iphone 6'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.form_factor == 'iphone 6'}
       end
 
       # Is the device under test an iPhone 6+?
       def iphone_6_plus?
-        Calabash::IOS::Device.default.form_factor == 'iphone 6 +'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.form_factor == 'iphone 6 +'}
       end
 
       # Is the device under test an iPhone 3.5in?
@@ -72,7 +72,7 @@ module Calabash
       # @see #iphone_app_emulated_on_ipad?
       # @see #ipad?
       def iphone_35in?
-        Calabash::IOS::Device.default.form_factor == 'iphone 3.5in'
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.form_factor == 'iphone 3.5in'}
       end
 
       # The screen dimensions and details about scale and sample rates.
@@ -88,7 +88,7 @@ module Calabash
       #
       # @return [Hash] See the example.
       def app_screen_details
-        Calabash::IOS::Device.default.screen_dimensions
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.screen_dimensions}
       end
 
       # The version of iOS running on the test device.
@@ -100,7 +100,7 @@ module Calabash
       #
       # @return [RunLoop::Version] A version object.
       def ios_version
-        Calabash::IOS::Device.default.ios_version
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.ios_version}
       end
 
       # Is the device under test running iOS 6?
@@ -132,7 +132,7 @@ module Calabash
       #
       # @return [RunLoop::Version] A version object.
       def server_version
-        Calabash::IOS::Device.default.server_version
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.server_version}
       end
 
       # Details about the version of the app under test.
@@ -161,7 +161,7 @@ module Calabash
       #  the methods in the {Calabash::IOS::Runtime} module instead.
       # @return[Hash] Key/value pairs that describe the runtime environment.
       def runtime_details
-        Calabash::IOS::Device.default.runtime_details
+        Calabash::IOS::Calabash::Internal.with_default_device(required_os: :ios) {|device| device.runtime_details}
       end
     end
   end

--- a/lib/calabash/ios/scroll.rb
+++ b/lib/calabash/ios/scroll.rb
@@ -71,7 +71,7 @@ module Calabash
           raise RuntimeError, e
         end
 
-        results = Device.default.map_route(query, :scroll, direction)
+        results = Calabash::Internal.with_default_device(required_os: :ios) {|device| device.map_route(query, :scroll, direction)}
 
         if results.first.nil?
           fail("Expected '#{query}' to match a UIScrollView or a subclass")
@@ -153,8 +153,10 @@ module Calabash
         position = merged_options[:scroll_position].to_sym
         animate = merged_options[:animate]
 
-        results = Device.default.map_route(query, :scrollToRow, row.to_i,
-                                          section.to_i, position, animate)
+        results = Calabash::Internal.with_default_device(required_os: :ios) do |device|
+          device.map_route(query, :scrollToRow, row.to_i,
+                           section.to_i, position, animate)
+        end
 
         if results.first.nil?
           message = [
@@ -240,8 +242,10 @@ module Calabash
         position = merged_options[:scroll_position].to_sym
         animate = merged_options[:animate]
 
-        results = Device.default.map_route(query, :scrollToRowWithMark, mark,
-                                          position, animate)
+        results = Calabash::Internal.with_default_device(required_os: :ios) do |device|
+          device.map_route(query, :scrollToRowWithMark, mark,
+                           position, animate)
+        end
 
         if results.first.nil?
           message = [
@@ -334,9 +338,12 @@ module Calabash
         position = merged_options[:scroll_position].to_sym
         animate = merged_options[:animate]
 
-        results = Device.default.map_route(query, :collectionViewScroll,
-                                           item.to_i, section.to_i,
-                                           position, animate)
+        results = Calabash::Internal.with_default_device(required_os: :ios) do |device|
+          device.map_route(query, :collectionViewScroll,
+                           item.to_i, section.to_i,
+                           position, animate)
+        end
+
         if results.first.nil?
           message = [
                 "Could not scroll collection to item '#{item}' and section '#{section}'.",
@@ -427,9 +434,11 @@ module Calabash
         position = merged_options[:scroll_position].to_sym
         animate = merged_options[:animate]
 
-        results = Device.default.map_route(query,
-                                           :collectionViewScrollToItemWithMark,
-                                           mark, position, animate)
+        results = Calabash::Internal.with_default_device(required_os: :ios) do |device|
+          device.map_route(query,
+                           :collectionViewScrollToItemWithMark,
+                           mark, position, animate)
+        end
 
         if results.first.nil?
           message = [

--- a/lib/calabash/ios/slider.rb
+++ b/lib/calabash/ios/slider.rb
@@ -63,7 +63,7 @@ module Calabash
 
         args = [merged_options[:animate], merged_options[:notify_targets]]
 
-        Device.default.map_route(query, :changeSlider, value_str, *args)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.map_route(query, :changeSlider, value_str, *args)}
       end
     end
   end

--- a/lib/calabash/ios/text.rb
+++ b/lib/calabash/ios/text.rb
@@ -7,7 +7,7 @@ module Calabash
         wait_for_keyboard
         existing_text = text_from_keyboard_first_responder
         options = { existing_text: existing_text }
-        Device.default.enter_text(text, options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.enter_text(text, options)}
       end
 
       # @!visibility private
@@ -50,7 +50,7 @@ module Calabash
       #
       # @return [Boolean] Returns true if a keyboard is visible and docked.
       def docked_keyboard_visible?
-        Device.default.docked_keyboard_visible?
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.docked_keyboard_visible?}
       end
 
       # Returns true if an undocked keyboard is visible.
@@ -60,7 +60,7 @@ module Calabash
       # @return [Boolean] Returns false if the device is not an iPad; all
       # keyboards on the iPhone and iPod are docked.
       def undocked_keyboard_visible?
-        Device.default.undocked_keyboard_visible?
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.undocked_keyboard_visible?}
       end
 
       # Returns true if a split keyboard is visible.
@@ -71,7 +71,7 @@ module Calabash
       # @return [Boolean] Returns false if the device is not an iPad; all
       # keyboards on the Phone and iPod are docked and not split.
       def split_keyboard_visible?
-        Device.default.split_keyboard_visible?
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.split_keyboard_visible?}
       end
 
       # Touches the keyboard action key.
@@ -98,7 +98,7 @@ module Calabash
         end
 
         wait_for_keyboard
-        Device.default.tap_keyboard_action_key
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.tap_keyboard_action_key}
       end
 
       # @!visibility private
@@ -150,7 +150,7 @@ module Calabash
       #  localization of 'Delete'.
       # @todo Need translations of 'Delete' key.
       def tap_keyboard_delete_key(options = {})
-        Device.default.tap_keyboard_delete_key(options)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.tap_keyboard_delete_key(options)}
       end
 
       # Returns the the text in the first responder.
@@ -164,7 +164,7 @@ module Calabash
       #
       # @raise [RuntimeError] If there is no visible keyboard.
       def text_from_keyboard_first_responder
-        Device.default.text_from_keyboard_first_responder
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.text_from_keyboard_first_responder}
       end
 
       private

--- a/lib/calabash/ios/uia.rb
+++ b/lib/calabash/ios/uia.rb
@@ -17,7 +17,7 @@ module Calabash
       #  uia("UIATarget.localTarget().frontMostApp().keyboard().buttons()['Delete']")
       #  uia("UIATarget.localTarget().frontMostApp().mainWindow().elements()")
       def uia(script)
-        Device.default.evaluate_uia(script)
+        Calabash::Internal.with_default_device(required_os: :ios) {|device| device.evaluate_uia(script)}
       end
 
       # Evaluates `script` after prefixing with "UIATarget.localTarget()"

--- a/lib/calabash/life_cycle.rb
+++ b/lib/calabash/life_cycle.rb
@@ -38,13 +38,13 @@ module Calabash
         raise 'No application given, and Calabash.default_application is not set'
       end
 
-      Device.default.start_app(path_or_application, options.dup)
+      Calabash::Internal.with_default_device {|device| device.start_app(path_or_application, options.dup)}
     end
 
     # Stop the app running on
     # {Calabash::Defaults#default_server Calabash.default_server}
     def stop_app
-      Device.default.stop_app
+      Calabash::Internal.with_default_device {|device| device.stop_app}
     end
 
     # Installs the given application. If the application is already installed,
@@ -67,7 +67,7 @@ module Calabash
         raise 'No application given, and Calabash.default_application is not set'
       end
 
-      Device.default.install_app(path_or_application)
+      Calabash::Internal.with_default_device {|device| device.install_app(path_or_application)}
     end
 
     # Installs the given application *if it is not already installed*. If no
@@ -90,7 +90,7 @@ module Calabash
         raise 'No application given, and Calabash.default_application is not set'
       end
 
-      Device.default.ensure_app_installed(path_or_application)
+      Calabash::Internal.with_default_device {|device| device.ensure_app_installed(path_or_application)}
     end
 
     # Uninstalls the given application. Does nothing if the application is
@@ -108,7 +108,7 @@ module Calabash
         raise 'No application given, and Calabash.default_application is not set'
       end
 
-      Device.default.uninstall_app(path_or_application)
+      Calabash::Internal.with_default_device {|device| device.uninstall_app(path_or_application)}
     end
 
     # Clears the contents of the given application. This is roughly equivalent to
@@ -126,7 +126,7 @@ module Calabash
         raise 'No application given, and Calabash.default_application is not set'
       end
 
-      Device.default.clear_app_data(path_or_application)
+      Calabash::Internal.with_default_device {|device| device.clear_app_data(path_or_application)}
     end
 
     # Sends the current app to the background and resumes it after

--- a/lib/calabash/location.rb
+++ b/lib/calabash/location.rb
@@ -25,7 +25,7 @@ module Calabash
         raise ArgumentError, 'You must supply :latitude and :longitude'
       end
 
-      Device.default.set_location(location)
+      Calabash::Internal.with_default_device {|device| device.set_location(location)}
     end
 
     # Get the latitude and longitude for a certain place, resolved via Google

--- a/lib/calabash/screenshot.rb
+++ b/lib/calabash/screenshot.rb
@@ -49,7 +49,7 @@ module Calabash
     # @param [String] name Name of the screenshot.
     # @return [String] Path to the screenshot
     def screenshot(name=nil)
-      Device.default.screenshot(name)
+      Calabash::Internal.with_default_device {|device| device.screenshot(name)}
     end
 
     # Takes a screenshot and embeds it in the test report. This method is only

--- a/spec/lib/android/text_spec.rb
+++ b/spec/lib/android/text_spec.rb
@@ -2,7 +2,7 @@ describe Calabash::Android::Text do
   let(:dummy_class) {Class.new {include Calabash::Android}}
   let(:world) {dummy_class.new}
 
-  let(:dummy_device_class) {Class.new(Calabash::Device) {def initialize; end}}
+  let(:dummy_device_class) {Class.new(Calabash::Android::Device) {def initialize; end}}
   let(:dummy_device) {dummy_device_class.new}
 
   before do

--- a/spec/lib/internal_spec.rb
+++ b/spec/lib/internal_spec.rb
@@ -1,0 +1,51 @@
+describe Calabash::Internal do
+  describe ".with_default_device" do
+    it 'will take a block that is called with the current device, if it is set' do
+      expected = :expected
+
+      expect(Calabash).to receive(:default_device).and_return(expected)
+
+      expect(Calabash::Internal.with_default_device {|device| device}).to eq(expected)
+    end
+
+    it 'will raise an error if the default device is not set' do
+      expected_message = "The default device is not set. Set it using Calabash.default_device = ..."
+
+      expect(Calabash).to receive(:default_device).and_return(nil)
+
+      expect{Calabash::Internal.with_default_device {|device| device}}.to raise_error(RuntimeError, expected_message)
+    end
+
+    describe 'takes an option argument required os' do
+      it 'will run if called with the correct device type' do
+        default_device = Calabash::Android::Device.allocate
+
+        expect(Calabash).to receive(:default_device).and_return(default_device)
+
+        expect(Calabash::Internal.with_default_device(required_os: :android) {|device| device}).to eq(default_device)
+
+        default_device = Calabash::IOS::Device.allocate
+
+        expect(Calabash).to receive(:default_device).and_return(default_device)
+
+        expect(Calabash::Internal.with_default_device(required_os: :ios) {|device| device}).to eq(default_device)
+      end
+
+      it 'will fail if not called with the correct device type' do
+        default_device = Calabash::Android::Device.allocate
+        expected_message = "The default device is not set to an iOS device, it is an Android device."
+
+        expect(Calabash).to receive(:default_device).and_return(default_device)
+
+        expect{Calabash::Internal.with_default_device(required_os: :ios) {|device| device}}.to raise_error(RuntimeError, expected_message)
+
+        default_device = Calabash::IOS::Device.allocate
+        expected_message = "The default device is not set to an Android device, it is an iOS device."
+
+        expect(Calabash).to receive(:default_device).and_return(default_device)
+
+        expect{Calabash::Internal.with_default_device(required_os: :android) {|device| device}}.to raise_error(RuntimeError, expected_message)
+      end
+    end
+  end
+end

--- a/spec/lib/ios/orientation_spec.rb
+++ b/spec/lib/ios/orientation_spec.rb
@@ -1,7 +1,8 @@
 describe Calabash::IOS::Orientation do
 
   let(:device) do
-    Class.new do
+    Class.new(Calabash::IOS::Device) do
+      def initialize; end
       def status_bar_orientation; ; end
       def rotate(_); ; end
       def rotate_home_button_to(_); ; end

--- a/spec/lib/ios/scroll_spec.rb
+++ b/spec/lib/ios/scroll_spec.rb
@@ -1,7 +1,8 @@
 describe Calabash::IOS::Scroll do
 
   let(:device) do
-    Class.new do
+    Class.new(Calabash::IOS::Device) do
+      def initialize; end
       def screenshot(_); end
       def map_route(_, _, *_) ; end
       def to_s; '#<Device>'; end

--- a/spec/lib/ios/text_spec.rb
+++ b/spec/lib/ios/text_spec.rb
@@ -1,6 +1,7 @@
 describe Calabash::IOS::Text do
   let(:device) do
-    Class.new do
+    Class.new(Calabash::IOS::Device) do
+      def initialize; end
       def uia_type_string(_, _); ; end
       def docked_keyboard_visible?; false; end
       def undocked_keyboard_visible?; false; end

--- a/spec/lib/ios/uia_spec.rb
+++ b/spec/lib/ios/uia_spec.rb
@@ -1,7 +1,8 @@
 describe Calabash::IOS::UIA do
 
   let(:device) do
-    Class.new do
+    Class.new(Calabash::IOS::Device) do
+      def initialize; end
       def evaluate_uia(_) ; end
     end.new
   end
@@ -16,8 +17,11 @@ describe Calabash::IOS::UIA do
 
   let(:script) { 'javascript' }
 
+  before do
+    allow(Calabash::Device).to receive(:default).at_least(:once).and_return device
+  end
+
   it '#uia' do
-    expect(Calabash::IOS::Device).to receive(:default).and_return device
     expect(device).to receive(:evaluate_uia).with(script).and_return :result
 
     expect(world.uia(script)).to be == :result
@@ -25,7 +29,6 @@ describe Calabash::IOS::UIA do
 
   it '#uia_with_target' do
     expected = "UIATarget.localTarget().#{script}"
-    expect(Calabash::IOS::Device).to receive(:default).and_return device
     expect(device).to receive(:evaluate_uia).with(expected).and_return :result
 
     expect(world.uia_with_target(script)).to be == :result
@@ -33,7 +36,6 @@ describe Calabash::IOS::UIA do
 
   it '#uia_with_app' do
     expected = "UIATarget.localTarget().frontMostApp().#{script}"
-    expect(Calabash::IOS::Device).to receive(:default).and_return device
     expect(device).to receive(:evaluate_uia).with(expected).and_return :result
 
     expect(world.uia_with_app(script)).to be == :result
@@ -41,7 +43,6 @@ describe Calabash::IOS::UIA do
 
   it '#uia_with_main_window' do
     expected = "UIATarget.localTarget().frontMostApp().mainWindow().#{script}"
-    expect(Calabash::IOS::Device).to receive(:default).and_return device
     expect(device).to receive(:evaluate_uia).with(expected).and_return :result
 
     expect(world.uia_with_main_window(script)).to be == :result


### PR DESCRIPTION
Using `with_default_device` allows us to raise a good error message if it is nil, or if it is the wrong platform.