### PR TITLE
iOS: Don't always restart sims in start_app

### DIFF
--- a/lib/calabash/ios/device/device_implementation.rb
+++ b/lib/calabash/ios/device/device_implementation.rb
@@ -329,6 +329,9 @@ module Calabash
 
       # @!visibility private
       def _start_app(application, options={})
+        # If the application is already running, then stop the application first
+        stop_app
+
         if application.simulator_bundle?
           start_app_on_simulator(application, options)
 
@@ -598,7 +601,7 @@ module Calabash
       # prepare the environment for simctl actions.
       def run_loop_bridge(run_loop_simulator_device, application)
         run_loop_app = RunLoop::App.new(application.path)
-        RunLoop::CoreSimulator.new(run_loop_simulator_device, run_loop_app)
+        RunLoop::CoreSimulator.new(run_loop_simulator_device, run_loop_app, quit_sim_on_init: false)
       end
 
       # @!visibility private
@@ -694,7 +697,8 @@ module Calabash
                     :app => application.path,
                     :bundle_id => application.identifier,
                     :device_target => run_loop_device.instruments_identifier(RunLoop::SimControl.new.xcode),
-                    :uia_strategy => strategy
+                    :uia_strategy => strategy,
+                    :quit_sim_on_init => false
               }
         @start_options = default_options.merge(options_from_user)
       end


### PR DESCRIPTION
This change is a bit controversial. We do not ask RunLoop to quit the
simulator when we want to start an application on it.

Note not RunLoop will *still* restart the sim if it determines that it
is not stable. I tried launching the sim from XCode, and RunLoop did
restart it.