### PR TITLE
Explicitly close file

### DIFF
--- a/lib/calabash/console_helpers.rb
+++ b/lib/calabash/console_helpers.rb
@@ -356,8 +356,11 @@ module Calabash
       if description && description.start_with?("@!visibility private")
         signature = nil
       end
+    
+      # Close file opened on line 319
+      file.close
 
-      [signature,description]
+      [signature, description]
     end
   end
 end


### PR DESCRIPTION
We've noticed some, too many files open for the system, errors on OS X, which is limited to 256. Not sure if this is related to this, but it is good practice to close opened files in Ruby.